### PR TITLE
Better pipeline support

### DIFF
--- a/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
+++ b/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
@@ -123,7 +123,14 @@ public final class Office365ConnectorWebhookNotifier {
     
     public static void sendBuildMessage(Run run, TaskListener listener, StepParameters stepParameters)
     {
-        Card card = getCard(run, listener, 3, stepParameters);
+        Card card;
+        if (StringUtils.isNotBlank(stepParameters.getMessage())) {
+            card = getCard(run, listener, 3, stepParameters);
+        } else if (StringUtils.equalsIgnoreCase(stepParameters.getStatus(), "started")) {
+            card = getCard(run, listener, 1);
+        } else {
+            card = getCard(run, listener, 2);
+        }
         if (card == null) {
             listener.getLogger().println(String.format("Build message card not generated."));
             return;

--- a/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
+++ b/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
@@ -458,9 +458,11 @@ public final class Office365ConnectorWebhookNotifier {
                 for (Cause cause : causes) {
                     causesStr.append(cause.getShortDescription()).append(". ");
                 }
-            factsList.add(new Facts("Remarks", causesStr.toString()));
-            
-            if (causesStr.toString().contains("SCM change")) {
+            String cause = causesStr.toString();
+            if (cause.contains("Branch indexing")) cause = cause.replace("Branch indexing", "SCM change");
+            factsList.add(new Facts("Remarks", cause));
+
+            if (cause.contains("SCM change")) {
                 addScmDetails(run, listener, factsList);
             }
         }

--- a/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
+++ b/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
@@ -334,7 +334,7 @@ public final class Office365ConnectorWebhookNotifier {
             factsList.add(new Facts("Status", "Running"));
         }
         
-        String activityTitle = "Update from build " + jobName + "(" + run.getNumber() + ")"; 
+        String activityTitle = "Update from build " + jobName + " (" + run.getNumber() + ")"; 
         Sections section = new Sections(activityTitle, stepParameters.getMessage(), factsList);
         
         List<Sections> sectionList = new ArrayList<>();

--- a/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
+++ b/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
@@ -214,8 +214,9 @@ public final class Office365ConnectorWebhookNotifier {
         Facts event = new Facts("Status");
         factsList.add(event);
         factsList.add(new Facts("Start Time", sdf.format(run.getStartTimeInMillis())));
-             
-        Result result = run.getResult();
+
+        // Result is only set to a worse status in pipeline
+        Result result = run.getResult() == null ? Result.SUCCESS : run.getResult();
         if (result != null) {
             long currentBuildCompletionTime = run.getStartTimeInMillis() + run.getDuration();
             factsList.add(new Facts("Completion Time", sdf.format(currentBuildCompletionTime)));
@@ -243,7 +244,7 @@ public final class Office365ConnectorWebhookNotifier {
             } catch (Throwable e) {
                 //listener.getLogger().println(e.getMessage());
             }
-            
+
             if (result == Result.SUCCESS && (previousResult == Result.FAILURE || previousResult == Result.UNSTABLE)) {
                 status = "Back to Normal";
                 summary += " Back to Normal";

--- a/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
+++ b/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
@@ -334,7 +334,7 @@ public final class Office365ConnectorWebhookNotifier {
             factsList.add(new Facts("Status", "Running"));
         }
         
-        String activityTitle = "Update from build " + jobName + " (" + run.getNumber() + ")"; 
+        String activityTitle = "Update from build " + jobName + " (#" + run.getNumber() + ")"; 
         Sections section = new Sections(activityTitle, stepParameters.getMessage(), factsList);
         
         List<Sections> sectionList = new ArrayList<>();

--- a/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
+++ b/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
@@ -218,7 +218,11 @@ public final class Office365ConnectorWebhookNotifier {
         // Result is only set to a worse status in pipeline
         Result result = run.getResult() == null ? Result.SUCCESS : run.getResult();
         if (result != null) {
-            long currentBuildCompletionTime = run.getStartTimeInMillis() + run.getDuration();
+            long duration = run.getDuration() == 0L
+                    ? System.currentTimeMillis() - run.getStartTimeInMillis()
+                    : run.getDuration();
+            long currentBuildCompletionTime = run.getStartTimeInMillis() + duration;
+
             factsList.add(new Facts("Completion Time", sdf.format(currentBuildCompletionTime)));
 
             AbstractTestResultAction<?> action = run.getAction(AbstractTestResultAction.class);

--- a/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
+++ b/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
@@ -464,12 +464,8 @@ public final class Office365ConnectorWebhookNotifier {
                     causesStr.append(cause.getShortDescription()).append(". ");
                 }
             String cause = causesStr.toString();
-            if (cause.contains("Branch indexing")) cause = cause.replace("Branch indexing", "SCM change");
             factsList.add(new Facts("Remarks", cause));
-
-            if (cause.contains("SCM change")) {
-                addScmDetails(run, listener, factsList);
-            }
+            addScmDetails(run, listener, factsList);
         }
     }
 }

--- a/src/main/java/jenkins/plugins/office365connector/workflow/Office365ConnectorSendStep.java
+++ b/src/main/java/jenkins/plugins/office365connector/workflow/Office365ConnectorSendStep.java
@@ -21,22 +21,21 @@ import org.kohsuke.stapler.DataBoundSetter;
  */
 public class Office365ConnectorSendStep extends AbstractStepImpl {
 
-    private final @Nonnull String message;
-    private String webhookUrl;
+    private String message;
+    private final String webhookUrl;
     private String status;
 
-    @Nonnull
     public String getMessage() {
         return message;
     }
 
-    public String getWebhookUrl() {
-        return webhookUrl;
+    @DataBoundSetter
+    public void setMessage(String message) {
+        this.message = message;
     }
 
-    @DataBoundSetter
-    public void setWebhookUrl(String url) {
-        this.webhookUrl = url;
+    public String getWebhookUrl() {
+        return webhookUrl;
     }
 
     public String getStatus() {
@@ -49,8 +48,8 @@ public class Office365ConnectorSendStep extends AbstractStepImpl {
     }
     
     @DataBoundConstructor
-    public Office365ConnectorSendStep(@Nonnull String message) {
-        this.message = message;
+    public Office365ConnectorSendStep(String webhookUrl) {
+        this.webhookUrl = webhookUrl;
     }
 
     @Extension


### PR DESCRIPTION
specifying status: "started" to get the regular started card
and then specifying only webhook you will get the completed card.

```
pipeline {
  agent any
  environment {
    HOOK = "https://outlook.office.com/webhook/x"
  }
  stages {
    stage("build") {
      steps {
        office365ConnectorSend status: "Started", webhookUrl: "${env.HOOK}"
      }
    }
  }
  post {
    success {
      office365ConnectorSend webhookUrl: "${env.HOOK}"
    }
    failure {
      office365ConnectorSend webhookUrl: "${env.HOOK}"
    }
  }
}
```

To see actual commit:
https://github.com/casz/office-365-connector-plugin/compare/51070a6c4bafbde562d2677ca81a4664b769f7df...BetterPipelineSupport?expand=1

PR #6 should be merged before this, but I need that commit to avoid major merge conflicts.