### PR TITLE
Added 'name' field so each connection can be identified

### DIFF
--- a/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
+++ b/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
@@ -62,7 +62,7 @@ public final class Office365ConnectorWebhookNotifier {
     {
         Card card = null;
         if ((run instanceof AbstractBuild<?,?> && isFromPrebuild) ||
-                (!(run instanceof AbstractBuild<?,?>) && !isFromPrebuild)) {
+                (run instanceof AbstractBuild<?,?> || isFromPrebuild)) {
             card = getCard(run, listener, 1);
         }
         

--- a/src/main/java/jenkins/plugins/office365connector/Webhook.java
+++ b/src/main/java/jenkins/plugins/office365connector/Webhook.java
@@ -23,6 +23,8 @@ public class Webhook {
 
     public static final Integer DEFAULT_TIMEOUT = 30000;
 
+    private String name;
+
     private String url;
 
     private boolean startNotification;
@@ -44,9 +46,10 @@ public class Webhook {
     private int timeout;
 
     @DataBoundConstructor
-    public Webhook(String url, boolean startNotification, boolean notifySuccess, boolean notifyAborted,
+    public Webhook(String name, String url, boolean startNotification, boolean notifySuccess, boolean notifyAborted,
                     boolean notifyNotBuilt, boolean notifyUnstable, boolean notifyFailure, boolean notifyBackToNormal,
                     boolean notifyRepeatedFailure, int timeout) {
+            this.name = name;
             this.url = url;
             this.startNotification = startNotification;
             this.notifySuccess = notifySuccess;
@@ -59,6 +62,9 @@ public class Webhook {
             this.timeout = timeout;
     }
 
+    public String getName() {
+            return name;
+    }
 
     public String getUrl() {
             return url;

--- a/src/main/resources/jenkins/plugins/office365connector/WebhookJobProperty/help-endpoints.html
+++ b/src/main/resources/jenkins/plugins/office365connector/WebhookJobProperty/help-endpoints.html
@@ -1,2 +1,1 @@
-<div>Sends notifications about Job status to the defined webhooks
-using HTTP protocols.</div>
+<div class="help">Sends notifications about Job status to the defined webhooks using HTTP protocols.</div>

--- a/src/main/resources/jenkins/plugins/office365connector/WebhookJobProperty/help-name.html
+++ b/src/main/resources/jenkins/plugins/office365connector/WebhookJobProperty/help-name.html
@@ -1,0 +1,2 @@
+<div align="help">Allows to provide name fo the connection.
+    Name is not mandatory but helps managing when there are many connection assigned to the build</div>

--- a/src/main/resources/jenkins/plugins/office365connector/WebhookJobProperty/help-timeout.html
+++ b/src/main/resources/jenkins/plugins/office365connector/WebhookJobProperty/help-timeout.html
@@ -1,1 +1,1 @@
-<div>Sets connection timeout (in milliseconds) for TCP and HTTP. Default timeout is 30 seconds (30,000 ms)</div>
+<div align="help">Sets connection timeout (in milliseconds) for TCP and HTTP. Default timeout is 30 seconds (30,000 ms)</div>

--- a/src/main/resources/jenkins/plugins/office365connector/WebhookJobProperty/help-url.html
+++ b/src/main/resources/jenkins/plugins/office365connector/WebhookJobProperty/help-url.html
@@ -1,6 +1,3 @@
-<div align="left">
-<ul>
-    <li>Paste the URL generated in the <a href="https://outlook.office365.com/connectors/GroupPicker/Index?Provider=JenkinsCI&src=store"> Connectors Page </a>, e.g.
-    http://outlook.office.com/webhook/...ca/JenkinsCI/...a7/user@tenant.com/test</li>
-</ul>
+<div align="help">Paste the URL generated in the <a href="https://outlook.office365.com/connectors/GroupPicker/Index?Provider=JenkinsCI&src=store"> Connectors Page </a>, e.g.
+    http://outlook.office.com/webhook/...ca/JenkinsCI/...a7/user@tenant.com/test
 </div>


### PR DESCRIPTION
The goal of this change is to allow to manage connections.
I have many connections added to the build so having only URL does does not help me to identify which connection is owned by who. For example when I was told that the connection can be removed, because subscriber does not exist any more it's not easy to confirm which connection should be deleted.

Name is not mandatory so it can be left empty