### PR TITLE
Allow additional parameter of "color" to be passed to office365ConnectorSend

### DIFF
--- a/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
+++ b/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
@@ -354,6 +354,11 @@ public final class Office365ConnectorWebhookNotifier {
         
         String summary = jobName + ": Build #" + run.getNumber() + " Status"; 
         Card card = new Card(summary, sectionList);
+                       
+        if (stepParameters.getColor() != null) {
+        	card.setThemeColor(stepParameters.getColor());
+        }
+        
         addPotentialAction(run, card);
 
         return card;

--- a/src/main/java/jenkins/plugins/office365connector/workflow/Office365ConnectorSendStep.java
+++ b/src/main/java/jenkins/plugins/office365connector/workflow/Office365ConnectorSendStep.java
@@ -24,7 +24,8 @@ public class Office365ConnectorSendStep extends AbstractStepImpl {
     private String message;
     private final String webhookUrl;
     private String status;
-
+    private String color;
+    
     public String getMessage() {
         return message;
     }
@@ -47,7 +48,16 @@ public class Office365ConnectorSendStep extends AbstractStepImpl {
         this.status = status;
     }
     
-    @DataBoundConstructor
+    public String getColor() {
+		return color;
+	}
+
+    @DataBoundSetter
+	public void setColor(String color) {
+		this.color = color;
+	}
+
+	@DataBoundConstructor
     public Office365ConnectorSendStep(String webhookUrl) {
         this.webhookUrl = webhookUrl;
     }
@@ -85,7 +95,7 @@ public class Office365ConnectorSendStep extends AbstractStepImpl {
 
         @Override
         protected Void run() throws Exception {
-            StepParameters stepParameters = new StepParameters(step.message, step.webhookUrl, step.status);
+            StepParameters stepParameters = new StepParameters(step.message, step.webhookUrl, step.status, step.color);
             Office365ConnectorWebhookNotifier.sendBuildMessage(run, listener, stepParameters);
             return null;
         }

--- a/src/main/java/jenkins/plugins/office365connector/workflow/StepParameters.java
+++ b/src/main/java/jenkins/plugins/office365connector/workflow/StepParameters.java
@@ -23,6 +23,7 @@ public class StepParameters {
     String message;
     String webhookUrl;
     String status;
+    String color;
     
     public String getMessage()
     {
@@ -39,9 +40,15 @@ public class StepParameters {
         return status;
     }
     
-    StepParameters(String message, String url, String status) {
+    public String getColor()
+    {
+        return color;
+    }  
+    
+    StepParameters(String message, String url, String status, String color) {
         this.message = message;
         this.webhookUrl = url;
         this.status = status;
+        this.color = color;
     }
 }


### PR DESCRIPTION
Allow additional parameter of 'color' to be passed to office365ConnectorSend command when used in a Jenkins pipeline. This will allow specifying the HEX color code of the card used to display when the 'message' attribute is set.

Example: office365ConnectorSend message: "My Message", status: "FAILURE", webhookUrl: "https://....", color: "d00000"

I have have found this useful for our Jenkinsfile based pipeline builds, where we create our own custom success and failure messages, and still want the traditional green and red coloring.