### PR TITLE
Add symbols

### DIFF
--- a/src/main/java/jenkins/plugins/office365connector/WebhookJobPropertyDescriptor.java
+++ b/src/main/java/jenkins/plugins/office365connector/WebhookJobPropertyDescriptor.java
@@ -22,12 +22,14 @@ import hudson.model.JobPropertyDescriptor;
 import net.sf.json.JSON;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.StaplerRequest;
 
 /**
  * Job Property Descriptor.
  */
 @Extension
+@Symbol("office365ConnectorWebhooks")
 public final class WebhookJobPropertyDescriptor extends JobPropertyDescriptor {
 
     public WebhookJobPropertyDescriptor() {

--- a/src/main/java/jenkins/plugins/office365connector/workflow/Office365ConnectorSendStep.java
+++ b/src/main/java/jenkins/plugins/office365connector/workflow/Office365ConnectorSendStep.java
@@ -11,6 +11,7 @@ import hudson.model.TaskListener;
 import hudson.util.FormValidation;
 import jenkins.plugins.office365connector.Office365ConnectorWebhookNotifier;
 import jenkins.plugins.office365connector.util.FormUtils;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
@@ -72,6 +73,7 @@ public class Office365ConnectorSendStep extends Step {
     }
 
     @Extension
+    @Symbol("office365ConnectorSend")
     public static class DescriptorImpl extends StepDescriptor {
 
         @Override


### PR DESCRIPTION
This is how looks now when symbols are added
(Symbol name `office365Webhooks` is open for debate)
```
properties([
  office365Webhooks([[url: 'http://awesome']])
])
```
Also #24 is reducing the need for generator to provide all attributes as seen below

Before you would get, prettified to show how lengthy it is 👍 
```
properties([
  [
    $class: 'WebhookJobProperty',
    webhooks: [[
      name: 'webhook',
      notifyAborted: false,
      notifyBackToNormal: false,
      notifyFailure: false,
      notifyNotBuilt: false,
      notifyRepeatedFailure: false,
      notifySuccess: false,
      notifyUnstable: false,
      startNotification: false,
      timeout: 30000,
      url: 'https://notsoawesome'
    ]]
  ]
])
```

office365ConnectorSend also got a symbol, so now you can do this
```
office365ConnectorSend 'http://awesome'
```