### PR TITLE
Fix Null Pointer Exception in DecisionMaker.isAtLeastOneRuleMatched

### DIFF
--- a/src/main/java/jenkins/plugins/office365connector/Webhook.java
+++ b/src/main/java/jenkins/plugins/office365connector/Webhook.java
@@ -149,7 +149,10 @@ public class Webhook extends AbstractDescribableImpl<Webhook> {
     }
 
     public List<Macro> getMacros() {
-        return macros;
+		if (macros == null) {
+			this.macros = Util.fixNull(macros);
+		}
+		return macros;
     }
 
     @DataBoundSetter


### PR DESCRIPTION
In a free style build, the following exception is encountered. Patch provided allows for normal function. 
`java.lang.NullPointerException
	at jenkins.plugins.office365connector.DecisionMaker.isAtLeastOneRuleMatched(DecisionMaker.java:54)
	at jenkins.plugins.office365connector.Office365ConnectorWebhookNotifier.sendBuildStartedNotification(Office365ConnectorWebhookNotifier.java:95)
	at jenkins.plugins.office365connector.WebhookJobProperty.prebuild(WebhookJobProperty.java:50)
	at hudson.model.AbstractBuild$AbstractBuildExecution.preBuild(AbstractBuild.java:798)
	at hudson.model.AbstractBuild$AbstractBuildExecution.preBuild(AbstractBuild.java:793)
	at hudson.model.AbstractBuild$AbstractBuildExecution.preBuild(AbstractBuild.java:789)
	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:501)
	at hudson.model.Run.execute(Run.java:1724)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:421)`