### PR TITLE
Use getDisplayName to determine display name

### DIFF
--- a/src/test/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifierTest.java
+++ b/src/test/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifierTest.java
@@ -1,20 +1,23 @@
 package jenkins.plugins.office365connector;
 
+import static jenkins.plugins.office365connector.Office365ConnectorWebhookNotifierIntegrationTest.mockJob;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.doReturn;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.when;
-import static org.powermock.api.mockito.PowerMockito.doReturn;
 
 import java.io.PrintStream;
 import java.util.Collection;
 import java.util.Collections;
 
+import hudson.model.Job;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.scm.ChangeLogSet;
 import mockit.Deencapsulation;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -24,19 +27,30 @@ import org.junit.rules.ExpectedException;
  */
 public class Office365ConnectorWebhookNotifierTest {
 
+    private static final String CUSTOM_RUN_NAME = "myCustomRunName";
+    private static final String JOB_NAME = "myFirstJob";
+    private static final String MULTI_BRANCH_NAME = "myFirstMultiBranchProject";
+
     @Rule
     public ExpectedException thrown = ExpectedException.none();
+    private Run run;
+    private TaskListener listener;
+
+    @Before
+    public void setUp() {
+        run = mock(Run.class);
+        listener = mock(TaskListener.class);
+    }
 
     @Test
     public void getAffectedFiles_ReturnsAffectedFiles() {
 
         // given
-        Run run = mock(Run.class);
         ChangeLogSet.Entry entry = mock(ChangeLogSet.Entry.class);
         Object patternFiles = Collections.emptyList();
         doReturn(patternFiles).when(entry).getAffectedFiles();
 
-        Office365ConnectorWebhookNotifier notifier = new Office365ConnectorWebhookNotifier(run, null);
+        Office365ConnectorWebhookNotifier notifier = new Office365ConnectorWebhookNotifier(run, listener);
 
         // when,
         Collection<ChangeLogSet.AffectedFile> files = Deencapsulation.invoke(notifier, "getAffectedFiles", entry);
@@ -50,8 +64,6 @@ public class Office365ConnectorWebhookNotifierTest {
     public void getAffectedFiles_OnException_ReturnsEmptyCollection() {
 
         // given
-        Run run = mock(Run.class);
-        TaskListener listener = mock(TaskListener.class);
         PrintStream stream = mock(PrintStream.class);
         when(listener.getLogger()).thenReturn(stream);
         ChangeLogSet.Entry entry = mock(ChangeLogSet.Entry.class);
@@ -65,5 +77,50 @@ public class Office365ConnectorWebhookNotifierTest {
         // then
         verify(entry, times(1)).getAffectedFiles();
         assertThat(files).isEmpty();
+    }
+
+    @Test
+    public void getDisplayName_ParentWithoutName() {
+
+        // given
+        Job job = mockJob("");
+        when(run.getParent()).thenReturn(job);
+        Office365ConnectorWebhookNotifier notifier = new Office365ConnectorWebhookNotifier(run, listener);
+
+        // when,
+        String getDisplayName = Deencapsulation.invoke(notifier, "getDisplayName");
+
+        // then
+        assertThat(getDisplayName).isEqualTo(JOB_NAME);
+    }
+
+    @Test
+    public void getDisplayName_ParentWithName() {
+
+        // given
+        Job job = mockJob(MULTI_BRANCH_NAME);
+        when(run.getParent()).thenReturn(job);
+        Office365ConnectorWebhookNotifier notifier = new Office365ConnectorWebhookNotifier(run, listener);
+
+        // when,
+        String getJobDisplayName = Deencapsulation.invoke(notifier, "getDisplayName");
+
+        // then
+        assertThat(getJobDisplayName).isEqualTo(MULTI_BRANCH_NAME + " » " + JOB_NAME);
+    }
+
+    @Test
+    public void getDisplayName_RunWithCustomName() throws Exception {
+
+        // given
+        when(run.hasCustomDisplayName()).thenReturn(true);
+        when(run.getDisplayName()).thenReturn(CUSTOM_RUN_NAME);
+        Office365ConnectorWebhookNotifier notifier = new Office365ConnectorWebhookNotifier(run, listener);
+
+        // when,
+        String getDisplayName = Deencapsulation.invoke(notifier, "getDisplayName");
+
+        // then
+        assertThat(getDisplayName).isEqualTo(CUSTOM_RUN_NAME);
     }
 }


### PR DESCRIPTION
Title is not very clear when using multibranch pipeline

We could use full display name as the simpler solution, however, it does not scale well with a very nested folder structure so we are checking job's parent folder type for a multibranch project type.

DisplayName for multibranch is just the branch name or "PR-xx"
here is an example of both
FullDisplayName = `Widex End User Team » iOS-BEYOND » development`
DisplayName = `development`

This is where I consider using a method and only going one level up when Multibranch project type.
so I would get `iOS-BEYOND » development` instead

fixes #50 
fixes #45 