### PR TITLE
Remove duplicated info in PR notifications.

### DIFF
--- a/src/main/java/jenkins/plugins/office365connector/ActionableBuilder.java
+++ b/src/main/java/jenkins/plugins/office365connector/ActionableBuilder.java
@@ -43,7 +43,6 @@ public class ActionableBuilder {
         List<PotentialAction> potentialActions = pullRequestActionable();
 
         potentialActions.add(buildViewBuild());
-        potentialActions.addAll(pullRequestActionable());
 
         return potentialActions;
     }


### PR DESCRIPTION
Calling pullRequestActionable() both when initializing ‘potentialActions’ and later with potentialActions.addAll(pullRequestActionable()) adds the Pull Request info Title, Author and the link to the PR twice to the notification card. (See image.)

<img width="718" alt="pr-double-info_blur" src="https://user-images.githubusercontent.com/38275574/38619837-55f3009c-3d9d-11e8-974d-5dd401d182ed.png">

Removed the 'addAll' since it seems to be not needed.