### PR TITLE
Don't create cards when webhooks don't exist

### DIFF
--- a/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
+++ b/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
@@ -72,7 +72,7 @@ public final class Office365ConnectorWebhookNotifier {
 
     public void sendBuildStartedNotification(boolean isFromPreBuild) {
         WebhookJobProperty property = (WebhookJobProperty) job.getProperty(WebhookJobProperty.class);
-        if (property == null || property.getWebhooks() == null || property.getWebhooks().size() == 0) {
+        if (property == null || property.getWebhooks() == null || property.getWebhooks().isEmpty()) {
             log("No webhooks to notify");
             return;
         }
@@ -95,7 +95,7 @@ public final class Office365ConnectorWebhookNotifier {
 
     public void sendBuildCompleteNotification() {
         WebhookJobProperty property = (WebhookJobProperty) job.getProperty(WebhookJobProperty.class);
-        if (property == null || property.getWebhooks() == null || property.getWebhooks().size() == 0) {
+        if (property == null || property.getWebhooks() == null || property.getWebhooks().isEmpty()) {
             log("No webhooks to notify");
             return;
         }

--- a/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
+++ b/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
@@ -71,17 +71,17 @@ public final class Office365ConnectorWebhookNotifier {
     }
 
     public void sendBuildStartedNotification(boolean isFromPreBuild) {
+        WebhookJobProperty property = (WebhookJobProperty) job.getProperty(WebhookJobProperty.class);
+        if (property == null || property.getWebhooks() == null || property.getWebhooks().size() == 0) {
+            log("No webhooks to notify");
+            return;
+        }
+
         Card card = null;
 
         boolean isBuild = run instanceof AbstractBuild<?, ?>;
         if ((isBuild && isFromPreBuild) || (!isBuild && !isFromPreBuild)) {
             card = createJobStartedCard();
-        }
-
-        WebhookJobProperty property = (WebhookJobProperty) job.getProperty(WebhookJobProperty.class);
-        if (property == null) {
-            log("No webhooks to notify");
-            return;
         }
 
         for (Webhook webhook : property.getWebhooks()) {

--- a/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
+++ b/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
@@ -73,7 +73,6 @@ public final class Office365ConnectorWebhookNotifier {
     public void sendBuildStartedNotification(boolean isFromPreBuild) {
         WebhookJobProperty property = (WebhookJobProperty) job.getProperty(WebhookJobProperty.class);
         if (property == null || property.getWebhooks() == null || property.getWebhooks().isEmpty()) {
-            log("No webhooks to notify");
             return;
         }
 
@@ -96,7 +95,6 @@ public final class Office365ConnectorWebhookNotifier {
     public void sendBuildCompleteNotification() {
         WebhookJobProperty property = (WebhookJobProperty) job.getProperty(WebhookJobProperty.class);
         if (property == null || property.getWebhooks() == null || property.getWebhooks().isEmpty()) {
-            log("No webhooks to notify");
             return;
         }
 

--- a/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
+++ b/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
@@ -94,13 +94,13 @@ public final class Office365ConnectorWebhookNotifier {
     }
 
     public void sendBuildCompleteNotification() {
-        Card card = createJobCompletedCard();
-
         WebhookJobProperty property = (WebhookJobProperty) job.getProperty(WebhookJobProperty.class);
-        if (property == null) {
+        if (property == null || property.getWebhooks() == null || property.getWebhooks().size() == 0) {
             log("No webhooks to notify");
             return;
         }
+
+        Card card = createJobCompletedCard();
 
         for (Webhook webhook : property.getWebhooks()) {
             if (decisionMaker.isStatusMatched(webhook) && decisionMaker.isAtLeastOneRuleMatched(webhook)) {


### PR DESCRIPTION
Currently, the plugin goes through all the work of creating a Card, even if no Webhook exists on the project to send the card to.

This change moves the "early exit" up prior to Card creation to avoid the overhead of card creation when it's not needed.

Fixes #73 