### PR TITLE
replace run number with custom run name instead of job name

### DIFF
--- a/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
+++ b/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
@@ -139,10 +139,10 @@ public final class Office365ConnectorWebhookNotifier {
 
         String jobName = getDisplayName();
         String activityTitle = "Update from " + jobName + ".";
-        String activitySubtitle = "Latest status of build #" + run.getNumber();
+        String activitySubtitle = "Latest status of build " + getRunName();
         Section section = new Section(activityTitle, activitySubtitle, factsBuilder.collect());
 
-        String summary = jobName + ": Build #" + run.getNumber() + " Started";
+        String summary = jobName + ": Build " + getRunName() + " Started";
         Card card = new Card(summary, section);
         card.setPotentialAction(potentialActionBuilder.buildActionable());
 
@@ -151,7 +151,7 @@ public final class Office365ConnectorWebhookNotifier {
 
     private Card createJobCompletedCard() {
         String jobName = getDisplayName();
-        String summary = jobName + ": Build #" + run.getNumber();
+        String summary = jobName + ": Build " + getRunName();
 
         Fact statusFact = FactsBuilder.buildStatus();
         factsBuilder.addFact(statusFact);
@@ -223,7 +223,7 @@ public final class Office365ConnectorWebhookNotifier {
         addScmDetails();
 
         String activityTitle = "Update from " + jobName + ".";
-        String activitySubtitle = "Latest status of build #" + run.getNumber();
+        String activitySubtitle = "Latest status of build " + getRunName();
         Section section = new Section(activityTitle, activitySubtitle, factsBuilder.collect());
 
         Card card = new Card(summary, section);
@@ -249,10 +249,10 @@ public final class Office365ConnectorWebhookNotifier {
             factsBuilder.addStatusRunning();
         }
 
-        String activityTitle = "Message from " + jobName + ", Build #" + run.getNumber() + "";
+        String activityTitle = "Message from " + jobName + ", Build " + getRunName() + "";
         Section section = new Section(activityTitle, stepParameters.getMessage(), factsBuilder.collect());
 
-        String summary = jobName + ": Build #" + run.getNumber() + " Status";
+        String summary = jobName + ": Build " + getRunName() + " Status";
         Card card = new Card(summary, section);
 
         if (stepParameters.getColor() != null) {
@@ -315,9 +315,13 @@ public final class Office365ConnectorWebhookNotifier {
     }
 
     private String getDisplayName() {
-        return run.hasCustomDisplayName() ? run.getDisplayName() : job.getFullDisplayName();
+        return job.getFullDisplayName();
     }
 
+    private String getRunName() {
+        return run.hasCustomDisplayName() ? run.getDisplayName() : "#" + run.getNumber();
+    }
+  
     /**
      * Helper method for logging.
      */

--- a/src/test/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifierTest.java
+++ b/src/test/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifierTest.java
@@ -27,6 +27,7 @@ import org.junit.rules.ExpectedException;
  */
 public class Office365ConnectorWebhookNotifierTest {
 
+    private static final int RUN_NUMBER = 42;
     private static final String CUSTOM_RUN_NAME = "myCustomRunName";
     private static final String JOB_NAME = "myFirstJob";
     private static final String MULTI_BRANCH_NAME = "myFirstMultiBranchProject";
@@ -110,17 +111,34 @@ public class Office365ConnectorWebhookNotifierTest {
     }
 
     @Test
-    public void getDisplayName_RunWithCustomName() throws Exception {
+    public void getDisplayName_RunWithoutCustomName() throws Exception {
 
         // given
-        when(run.hasCustomDisplayName()).thenReturn(true);
+        when(run.hasCustomDisplayName()).thenReturn(false);
+        when(run.getNumber()).thenReturn(RUN_NUMBER);
         when(run.getDisplayName()).thenReturn(CUSTOM_RUN_NAME);
         Office365ConnectorWebhookNotifier notifier = new Office365ConnectorWebhookNotifier(run, listener);
 
         // when,
-        String getDisplayName = Deencapsulation.invoke(notifier, "getDisplayName");
+        String getRunName = Deencapsulation.invoke(notifier, "getRunName");
 
         // then
-        assertThat(getDisplayName).isEqualTo(CUSTOM_RUN_NAME);
+        assertThat(getRunName).isEqualTo("#" + RUN_NUMBER);
+    }
+  
+    @Test
+    public void getDisplayName_RunWithCustomName() throws Exception {
+
+        // given
+        when(run.hasCustomDisplayName()).thenReturn(true);
+        when(run.getNumber()).thenReturn(RUN_NUMBER);
+        when(run.getDisplayName()).thenReturn(CUSTOM_RUN_NAME);
+        Office365ConnectorWebhookNotifier notifier = new Office365ConnectorWebhookNotifier(run, listener);
+
+        // when,
+        String getRunName = Deencapsulation.invoke(notifier, "getRunName");
+
+        // then
+        assertThat(getRunName).isEqualTo(CUSTOM_RUN_NAME);
     }
 }


### PR DESCRIPTION
Instead of replacing the Job Name on a card when a custom build run name is set, the run number will be replaced.