### PR TITLE
add custom message option to freestyle projects

### DIFF
--- a/src/main/java/jenkins/plugins/office365connector/FactsBuilder.java
+++ b/src/main/java/jenkins/plugins/office365connector/FactsBuilder.java
@@ -13,19 +13,25 @@
  */
 package jenkins.plugins.office365connector;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
+import hudson.EnvVars;
 import hudson.model.Cause;
 import hudson.model.Run;
 import hudson.model.User;
+import hudson.util.LogTaskListener;
 import hudson.tasks.test.AbstractTestResultAction;
 import jenkins.plugins.office365connector.model.Fact;
 import jenkins.plugins.office365connector.utils.TimeUtils;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
+
 
 /**
  * Collects helper methods that create instance of {@link jenkins.plugins.office365connector.model.Fact Fact} class.
@@ -51,6 +57,8 @@ public class FactsBuilder {
     final static String NAME_SKIPPED_TESTS = "Skipped tests";
     final static String NAME_PASSED_TESTS = "Passed tests";
 
+    final static String ADDITIONAL_INFO = "Additional info";
+
     private final List<Fact> facts = new ArrayList<>();
     private final Run run;
 
@@ -73,6 +81,7 @@ public class FactsBuilder {
     public void addStartTime() {
         addFact(NAME_START_TIME, TimeUtils.dateToString(run.getStartTimeInMillis()));
     }
+
 
     public void addBackToNormalTime(long duration) {
         addFact(NAME_BACK_TO_NORMAL_TIME, TimeUtils.dateToString(duration));
@@ -144,6 +153,12 @@ public class FactsBuilder {
         addFact(NAME_SKIPPED_TESTS, action.getSkipCount());
     }
 
+    public void addCustom(String message, Run run) throws IOException, InterruptedException {
+        EnvVars envVars;
+        envVars = run.getEnvironment(new LogTaskListener(LOGGER, Level.INFO));
+        addFact(ADDITIONAL_INFO, envVars.expand(message));
+    }
+
     public void addFact(String name, int value) {
         addFact(name, String.valueOf(value));
     }
@@ -166,4 +181,6 @@ public class FactsBuilder {
     public List<Fact> collect() {
         return facts;
     }
+
+    private static final Logger LOGGER = Logger.getLogger(FactsBuilder.class.getName());
 }

--- a/src/main/java/jenkins/plugins/office365connector/Webhook.java
+++ b/src/main/java/jenkins/plugins/office365connector/Webhook.java
@@ -36,6 +36,7 @@ public class Webhook extends AbstractDescribableImpl<Webhook> {
 
     private String name;
     private String url;
+    private String customMessage;
 
     private boolean startNotification;
     private boolean notifySuccess;
@@ -45,6 +46,7 @@ public class Webhook extends AbstractDescribableImpl<Webhook> {
     private boolean notifyFailure;
     private boolean notifyBackToNormal;
     private boolean notifyRepeatedFailure;
+    private boolean includeCustomMessage;
 
     private int timeout;
 
@@ -66,6 +68,13 @@ public class Webhook extends AbstractDescribableImpl<Webhook> {
     @DataBoundSetter
     public void setName(String name) {
         this.name = Util.fixEmptyAndTrim(name);
+    }
+
+    public String getCustomMessage() { return customMessage; }
+
+    @DataBoundSetter
+    public void setCustomMessage(String customMessage) {
+        this.customMessage = Util.fixEmptyAndTrim(customMessage);
     }
 
     public boolean isNotifySuccess() {
@@ -160,6 +169,10 @@ public class Webhook extends AbstractDescribableImpl<Webhook> {
     public void setMacros(List<Macro> macros) {
         this.macros = Util.fixNull(macros);
     }
+
+    @DataBoundSetter
+    public void setIncludeCustomMessage(boolean includeCustomMessage) { this.includeCustomMessage = includeCustomMessage; }
+    public boolean isIncludeCustomMessage() { return includeCustomMessage; }
 
     @Override
     public String toString() {

--- a/src/main/resources/jenkins/plugins/office365connector/Webhook/config.jelly
+++ b/src/main/resources/jenkins/plugins/office365connector/Webhook/config.jelly
@@ -46,6 +46,13 @@
             </f:entry>
         </f:section>
 
+        <f:optionalBlock title="Include Custom Message" name="includeCustomMessage" inline="true"
+            checked="${instance.customMessage != null}">
+            <f:entry title="Custom Message" field="customMessage">
+                <f:textarea />
+            </f:entry>
+        </f:optionalBlock>
+
         <f:section title="Advanced configuration">
             <f:entry title="Macros" field="macros">
                 <f:repeatableProperty minimum="0" field="macros" add="${%Add Macro}">

--- a/src/main/resources/jenkins/plugins/office365connector/Webhook/help-customMessage.html
+++ b/src/main/resources/jenkins/plugins/office365connector/Webhook/help-customMessage.html
@@ -1,0 +1,5 @@
+<div align="help">
+  Enter a custom message that will be included with the notifications.
+
+  This field support markdown syntax and build variables in the form <a href="https://wiki.jenkins-ci.org/display/JENKINS/Building+a+software+project#Buildingasoftwareproject-JenkinsSetEnvironmentVariables">Jenkins Environment Variables</a> by putting $VAR_NAME where you want it to appear.
+</div>


### PR DESCRIPTION
Add the option to include additional info in the message generated by the connector used in Jenkins Freestyle projects.

This enables users to expose relevant information such as build parameters, environment variables and so on.

For pipelines this is already possible by providing a custom message when invoking the `office365ConnectorSend` function, but nothing was available for freestyle projects.

The options screen would now look like:

![config](https://user-images.githubusercontent.com/1335181/54025077-1a1b1280-41a2-11e9-9017-8e2515d9e39f.PNG)

The results would look like:

![output](https://user-images.githubusercontent.com/1335181/54025087-21422080-41a2-11e9-9134-ed683c30996c.PNG)

This change is relevant to #86, #75  and can be expanded to support #76 .