### PR TITLE
Use seconds for back to normal time

### DIFF
--- a/src/main/java/jenkins/plugins/office365connector/FactsBuilder.java
+++ b/src/main/java/jenkins/plugins/office365connector/FactsBuilder.java
@@ -75,7 +75,7 @@ public class FactsBuilder {
     }
 
     public void addBackToNormalTime(long duration) {
-        addFact(NAME_BACK_TO_NORMAL_TIME, TimeUtils.durationToString(duration));
+        addFact(NAME_BACK_TO_NORMAL_TIME, TimeUtils.durationToString(duration / 1000));
     }
 
     public void addCompletionTime() {

--- a/src/test/java/jenkins/plugins/office365connector/FactsBuilderTest.java
+++ b/src/test/java/jenkins/plugins/office365connector/FactsBuilderTest.java
@@ -36,11 +36,11 @@ public class FactsBuilderTest {
     public void addBackToNormalTime_AddsFact() {
 
         // given
-        long backToNormalDuration = 1000L;
+        long backToNormalDuration = 1000000L;
         String durationString = "16 minutes, 40 seconds";
 
         PowerMockito.mockStatic(TimeUtils.class);
-        BDDMockito.given(TimeUtils.durationToString(backToNormalDuration)).willReturn(durationString);
+        BDDMockito.given(TimeUtils.durationToString(backToNormalDuration / 1000)).willReturn(durationString);
 
         FactsBuilder factBuilder = new FactsBuilder(run);
 


### PR DESCRIPTION
Back to normal time stores duration in milliseconds. However, it uses the `durationToString` utility method which expects seconds. This pull request converts the milliseconds to seconds in `addBackToNormalTime` before attempting to create the duration string.