### PR TITLE
Use pre tags to escape job titles from markdown

### DIFF
--- a/src/main/java/jenkins/plugins/office365connector/CardBuilder.java
+++ b/src/main/java/jenkins/plugins/office365connector/CardBuilder.java
@@ -46,7 +46,7 @@ public class CardBuilder {
         factsBuilder.addDevelopers();
 
         String jobName = getDisplayName();
-        String activityTitle = "Update from " + jobName + ".";
+        String activityTitle = "<pre>Update from " + jobName + ".</pre>";
         String activitySubtitle = "Latest status of build " + getRunName();
         Section section = new Section(activityTitle, activitySubtitle, factsBuilder.collect());
 
@@ -119,7 +119,7 @@ public class CardBuilder {
         factsBuilder.addCulprits();
         factsBuilder.addDevelopers();
 
-        String activityTitle = "Update from " + jobName + ".";
+        String activityTitle = "<pre>Update from " + jobName + ".</pre>";
         String activitySubtitle = "Latest status of build " + getRunName();
         Section section = new Section(activityTitle, activitySubtitle, factsBuilder.collect());
 
@@ -144,7 +144,7 @@ public class CardBuilder {
             factsBuilder.addStatusRunning();
         }
 
-        String activityTitle = "Message from " + jobName + ", Build " + getRunName() + "";
+        String activityTitle = "<pre>Message from " + jobName + ", Build " + getRunName() + "</pre>";
         Section section = new Section(activityTitle, stepParameters.getMessage(), factsBuilder.collect());
 
         String summary = jobName + ": Build " + getRunName() + " Status";

--- a/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
+++ b/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
@@ -38,7 +38,7 @@ import org.apache.commons.lang.StringUtils;
 public final class Office365ConnectorWebhookNotifier {
 
     private static final Gson gson = new GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.IDENTITY)
-            .setPrettyPrinting().create();
+            .disableHtmlEscaping().setPrettyPrinting().create();
 
     private final CardBuilder cardBuilder;
     private final DecisionMaker decisionMaker;

--- a/src/test/resources/requests/completed-failure.json
+++ b/src/test/resources/requests/completed-failure.json
@@ -18,7 +18,7 @@
                     "value": "Mike"
                 }
             ],
-            "activityTitle": "Update from myFirstJob.",
+            "activityTitle": "<pre>Update from myFirstJob.</pre>",
             "activitySubtitle": "Latest status of build #167"
         }
     ],

--- a/src/test/resources/requests/completed-success.json
+++ b/src/test/resources/requests/completed-success.json
@@ -18,7 +18,7 @@
                     "value": "Mike"
                 }
             ],
-            "activityTitle": "Update from myFirstJob.",
+            "activityTitle": "<pre>Update from myFirstJob.</pre>",
             "activitySubtitle": "Latest status of build #167"
         }
     ],

--- a/src/test/resources/requests/started-developers.json
+++ b/src/test/resources/requests/started-developers.json
@@ -14,7 +14,7 @@
                     "value": "Peter, George Great, Ann, the Queen"
                 }
             ],
-            "activityTitle": "Update from simple job.",
+            "activityTitle": "<pre>Update from simple job.</pre>",
             "activitySubtitle": "Latest status of build #1"
         }
     ],

--- a/src/test/resources/requests/started.json
+++ b/src/test/resources/requests/started.json
@@ -18,7 +18,7 @@
                     "value": "Mike"
                 }
             ],
-            "activityTitle": "Update from myFirstJob.",
+            "activityTitle": "<pre>Update from myFirstJob.</pre>",
             "activitySubtitle": "Latest status of build #167"
         }
     ],


### PR DESCRIPTION
This ensures jobs with names that include [text formatting characters](https://docs.microsoft.com/en-gb/outlook/actionable-messages/message-card-reference#text-formatting) or markdown alternatives documented [here](https://www.markdownguide.org/basic-syntax) are not formatted in the Card title e.g. 
`java_job_name` -> java*job*name
 or 
`develop__java__job_name` ->  develop**java**job_name.

This pull request resolves this by wrapping the `activityTitle` with `<pre>` tags and disabling html escaping for Gson.

Fixes this particular comment: https://github.com/jenkinsci/office-365-connector-plugin/issues/82#issuecomment-481668504