### PR TITLE
Skip all aborted builds when notifying back to normal

### DIFF
--- a/src/main/java/jenkins/plugins/office365connector/DecisionMaker.java
+++ b/src/main/java/jenkins/plugins/office365connector/DecisionMaker.java
@@ -109,7 +109,11 @@ public class DecisionMaker {
     }
 
     private boolean isNotifyBackToNormal(Result result, Webhook webhook) {
-        return result == Result.SUCCESS && (previousResult == Result.FAILURE || previousResult == Result.UNSTABLE)
+        Run previousBuild = run.getPreviousBuild();
+        while (null != previousBuild && previousBuild.getResult() == Result.ABORTED) {
+            previousBuild = previousBuild.getPreviousCompletedBuild();
+        }
+        return result == Result.SUCCESS && previousBuild != null && (previousBuild.getResult() == Result.FAILURE || previousBuild.getResult() == Result.UNSTABLE)
                 && webhook.isNotifyBackToNormal();
     }
 


### PR DESCRIPTION
Fixes #62 

Essentially stolen from https://github.com/jenkinsci/slack-plugin/blob/06b17f20cfa752f037b59a7670ac6d3fbf793517/src/main/java/jenkins/plugins/slack/ActiveNotifier.java#L134-L137

When checking for back to normal status, keep getting previous builds until a non-unstable build is found.  If all previous builds going back to the very first build are unstable, don't notify.