### PR TITLE
Add missing comma on sample code of FactDefinitions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ pipeline {
 
     post {
         failure {
-            office365ConnectorSend webhookUrl: "https://outlook.office.com/webhook/123456..."
+            office365ConnectorSend webhookUrl: "https://outlook.office.com/webhook/123456...",
                 factDefinitions: [[name: "fact1", template: "content of fact1"],
                                   [name: "fact2", template: "content of fact2"]]
         }


### PR DESCRIPTION
I forgot to add comma at https://github.com/jenkinsci/office-365-connector-plugin/pull/190
