### PR TITLE
Resolves #192 - Use green color for successful build card theme.

### DIFF
--- a/src/main/java/jenkins/plugins/office365connector/CardBuilder.java
+++ b/src/main/java/jenkins/plugins/office365connector/CardBuilder.java
@@ -95,8 +95,9 @@ public class CardBuilder {
     }
 
     private static String getCardThemeColor(Result result) {
-        if (result != null && result == Result.SUCCESS) {
-            return String.format("#%06X", Color.GREEN.getRGB() & 0xFFFFFF);
+        if (result == Result.SUCCESS) {
+            // Return green for success
+            return "0x00FF00";
         } else {
             return result.color.getHtmlBaseColor();
         }

--- a/src/main/java/jenkins/plugins/office365connector/CardBuilder.java
+++ b/src/main/java/jenkins/plugins/office365connector/CardBuilder.java
@@ -14,6 +14,7 @@
 package jenkins.plugins.office365connector;
 
 import java.util.List;
+import java.awt.*;
 
 import hudson.model.Result;
 import hudson.model.Run;
@@ -87,10 +88,18 @@ public class CardBuilder {
         Section section = buildSection();
 
         Card card = new Card(summary, section);
-        card.setThemeColor(lastResult.color.getHtmlBaseColor());
+        card.setThemeColor(getCardThemeColor(lastResult));
         card.setPotentialAction(potentialActionBuilder.buildActionable());
 
         return card;
+    }
+
+    private String getCardThemeColor(Result result) {
+        if (result == Result.SUCCESS) {
+            return String.format("#%06X", Color.GREEN.getRGB() & 0xFFFFFF);
+        } else {
+            return result.color.getHtmlBaseColor();
+        }
     }
 
     private Section buildSection() {

--- a/src/main/java/jenkins/plugins/office365connector/CardBuilder.java
+++ b/src/main/java/jenkins/plugins/office365connector/CardBuilder.java
@@ -94,8 +94,8 @@ public class CardBuilder {
         return card;
     }
 
-    private String getCardThemeColor(Result result) {
-        if (result == Result.SUCCESS) {
+    private static String getCardThemeColor(Result result) {
+        if (result != null && result == Result.SUCCESS) {
             return String.format("#%06X", Color.GREEN.getRGB() & 0xFFFFFF);
         } else {
             return result.color.getHtmlBaseColor();

--- a/src/main/java/jenkins/plugins/office365connector/CardBuilder.java
+++ b/src/main/java/jenkins/plugins/office365connector/CardBuilder.java
@@ -96,7 +96,7 @@ public class CardBuilder {
     private static String getCardThemeColor(Result result) {
         if (result == Result.SUCCESS) {
             // Return green for success
-            return "0x00FF00";
+            return "#00FF00";
         } else {
             return result.color.getHtmlBaseColor();
         }

--- a/src/main/java/jenkins/plugins/office365connector/CardBuilder.java
+++ b/src/main/java/jenkins/plugins/office365connector/CardBuilder.java
@@ -14,7 +14,6 @@
 package jenkins.plugins.office365connector;
 
 import java.util.List;
-import java.awt.*;
 
 import hudson.model.Result;
 import hudson.model.Run;

--- a/src/test/java/jenkins/plugins/office365connector/CardBuilderTest.java
+++ b/src/test/java/jenkins/plugins/office365connector/CardBuilderTest.java
@@ -5,6 +5,7 @@ import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 import java.util.Collections;
+import java.awt.*;
 
 import hudson.model.AbstractBuild;
 import hudson.model.ItemGroup;
@@ -504,5 +505,55 @@ public class CardBuilderTest extends AbstractTest {
 
         // then
         assertThat(displayName).isEqualTo("this\\_is\\_my\\-very\\#special \\*job\\*");
+    }
+
+    @Test
+    public void getCardThemeColor_OnSuccessResult_ReturnsGreen() {
+        Result successResult = Result.SUCCESS;
+        String themeColor = Deencapsulation.invoke(CardBuilder.class, "getCardThemeColor", successResult);
+        
+        String greenColorString = String.format("#%06X", Color.GREEN.getRGB() & 0xFFFFFF);
+
+        assertThat(themeColor).isEqualToIgnoringCase(greenColorString);
+    }
+
+    @Test
+    public void getCardThemeColor_OnAbortedResult_ReturnsBallColor() {
+        Result abortedResult = Result.ABORTED;
+        String themeColor = Deencapsulation.invoke(CardBuilder.class, "getCardThemeColor", abortedResult);
+        
+        String ballColorString = Result.ABORTED.color.getHtmlBaseColor();
+
+        assertThat(themeColor).isEqualToIgnoringCase(ballColorString);
+    }
+
+    @Test
+    public void getCardThemeColor_OnFailureResult_ReturnsBallColor() {
+        Result failureResult = Result.FAILURE;
+        String themeColor = Deencapsulation.invoke(CardBuilder.class, "getCardThemeColor", failureResult);
+        
+        String ballColorString = Result.FAILURE.color.getHtmlBaseColor();
+
+        assertThat(themeColor).isEqualToIgnoringCase(ballColorString);
+    }
+
+    @Test
+    public void getCardThemeColor_OnNotBuiltResult_ReturnsBallColor() {
+        Result notBuiltResult = Result.NOT_BUILT;
+        String themeColor = Deencapsulation.invoke(CardBuilder.class, "getCardThemeColor", notBuiltResult);
+        
+        String ballColorString = Result.NOT_BUILT.color.getHtmlBaseColor();
+
+        assertThat(themeColor).isEqualToIgnoringCase(ballColorString);
+    }
+
+    @Test
+    public void getCardThemeColor_OnUnstableResult_ReturnsBallColor() {
+        Result unstableResult = Result.UNSTABLE;
+        String themeColor = Deencapsulation.invoke(CardBuilder.class, "getCardThemeColor", unstableResult);
+        
+        String ballColorString = Result.UNSTABLE.color.getHtmlBaseColor();
+
+        assertThat(themeColor).isEqualToIgnoringCase(ballColorString);
     }
 }

--- a/src/test/java/jenkins/plugins/office365connector/CardBuilderTest.java
+++ b/src/test/java/jenkins/plugins/office365connector/CardBuilderTest.java
@@ -5,7 +5,6 @@ import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 import java.util.Collections;
-import java.awt.*;
 
 import hudson.model.AbstractBuild;
 import hudson.model.ItemGroup;

--- a/src/test/java/jenkins/plugins/office365connector/CardBuilderTest.java
+++ b/src/test/java/jenkins/plugins/office365connector/CardBuilderTest.java
@@ -510,7 +510,7 @@ public class CardBuilderTest extends AbstractTest {
     public void getCardThemeColor_OnSuccessResult_ReturnsGreen() {
         // given
         Result successResult = Result.SUCCESS;
-        String greenColorString = "0x00FF00";
+        String greenColorString = "#00FF00";
 
         // when
         String themeColor = Deencapsulation.invoke(CardBuilder.class, "getCardThemeColor", successResult);

--- a/src/test/java/jenkins/plugins/office365connector/CardBuilderTest.java
+++ b/src/test/java/jenkins/plugins/office365connector/CardBuilderTest.java
@@ -509,51 +509,66 @@ public class CardBuilderTest extends AbstractTest {
 
     @Test
     public void getCardThemeColor_OnSuccessResult_ReturnsGreen() {
+        // given
         Result successResult = Result.SUCCESS;
+        String greenColorString = "0x00FF00";
+
+        // when
         String themeColor = Deencapsulation.invoke(CardBuilder.class, "getCardThemeColor", successResult);
         
-        String greenColorString = String.format("#%06X", Color.GREEN.getRGB() & 0xFFFFFF);
-
+        // then
         assertThat(themeColor).isEqualToIgnoringCase(greenColorString);
     }
 
     @Test
     public void getCardThemeColor_OnAbortedResult_ReturnsBallColor() {
+        // given
         Result abortedResult = Result.ABORTED;
-        String themeColor = Deencapsulation.invoke(CardBuilder.class, "getCardThemeColor", abortedResult);
-        
         String ballColorString = Result.ABORTED.color.getHtmlBaseColor();
 
+        // when
+        String themeColor = Deencapsulation.invoke(CardBuilder.class, "getCardThemeColor", abortedResult);
+        
+        // then
         assertThat(themeColor).isEqualToIgnoringCase(ballColorString);
     }
 
     @Test
     public void getCardThemeColor_OnFailureResult_ReturnsBallColor() {
+        // given
         Result failureResult = Result.FAILURE;
-        String themeColor = Deencapsulation.invoke(CardBuilder.class, "getCardThemeColor", failureResult);
-        
         String ballColorString = Result.FAILURE.color.getHtmlBaseColor();
 
+        // when
+        String themeColor = Deencapsulation.invoke(CardBuilder.class, "getCardThemeColor", failureResult);
+        
+        // then
         assertThat(themeColor).isEqualToIgnoringCase(ballColorString);
     }
 
     @Test
     public void getCardThemeColor_OnNotBuiltResult_ReturnsBallColor() {
+        // given
         Result notBuiltResult = Result.NOT_BUILT;
-        String themeColor = Deencapsulation.invoke(CardBuilder.class, "getCardThemeColor", notBuiltResult);
-        
         String ballColorString = Result.NOT_BUILT.color.getHtmlBaseColor();
 
+        // when
+        String themeColor = Deencapsulation.invoke(CardBuilder.class, "getCardThemeColor", notBuiltResult);
+
+        // then
         assertThat(themeColor).isEqualToIgnoringCase(ballColorString);
     }
 
     @Test
     public void getCardThemeColor_OnUnstableResult_ReturnsBallColor() {
+        // given
         Result unstableResult = Result.UNSTABLE;
-        String themeColor = Deencapsulation.invoke(CardBuilder.class, "getCardThemeColor", unstableResult);
-        
         String ballColorString = Result.UNSTABLE.color.getHtmlBaseColor();
 
+        // when
+        String themeColor = Deencapsulation.invoke(CardBuilder.class, "getCardThemeColor", unstableResult);
+        
+        // then
         assertThat(themeColor).isEqualToIgnoringCase(ballColorString);
     }
 }

--- a/src/test/resources/requests/back_to_normal-pull_request.json
+++ b/src/test/resources/requests/back_to_normal-pull_request.json
@@ -1,6 +1,6 @@
 {
     "summary": "Damian Szczepanik » hook » PR-1: Build #3 Back to Normal",
-    "themeColor": "#729FCF",
+    "themeColor": "#00FF00",
     "sections": [
         {
             "markdown": true,

--- a/src/test/resources/requests/completed-success.json
+++ b/src/test/resources/requests/completed-success.json
@@ -1,6 +1,6 @@
 {
     "summary": "Parent project » myFirst_Job_: Build #167 Success",
-    "themeColor": "#729FCF",
+    "themeColor": "#00FF00",
     "sections": [
         {
             "markdown": true,


### PR DESCRIPTION
Didn't see any tests that need updated.  
I would have liked to consolidate the ```getHTMLBaseColor()``` method into a Util class so that the string creation logic can be shared but that change would have been out of the scope of this repository.