### PR TITLE
Support for Proxy Implementations that needs Preemptive authentication

### DIFF
--- a/src/main/java/jenkins/plugins/office365connector/HttpWorker.java
+++ b/src/main/java/jenkins/plugins/office365connector/HttpWorker.java
@@ -110,6 +110,7 @@ public class HttpWorker implements Runnable {
                 String password = proxy.getPassword();
                 // Consider it to be passed if username specified. Sufficient?
                 if (StringUtils.isNotBlank(username)) {
+                    client.getParams().setAuthenticationPreemptive(true);
                     client.getState().setProxyCredentials(AuthScope.ANY,
                             new UsernamePasswordCredentials(username, password));
                 }


### PR DESCRIPTION
for issues #201 add the call to `setAuthenticationPreemptive(true)` to support proxy calls that do not return unauthenticated status.  
