### PR TITLE
Remove "Status: Running" from notifications

### DIFF
--- a/src/main/java/jenkins/plugins/office365connector/CardBuilder.java
+++ b/src/main/java/jenkins/plugins/office365connector/CardBuilder.java
@@ -179,8 +179,6 @@ public class CardBuilder {
     public Card createBuildMessageCard(StepParameters stepParameters) {
         if (stepParameters.getStatus() != null) {
             factsBuilder.addStatus(stepParameters.getStatus());
-        } else {
-            factsBuilder.addStatusRunning();
         }
         factsBuilder.addUserFacts(stepParameters.getFactDefinitions());
 

--- a/src/main/java/jenkins/plugins/office365connector/FactsBuilder.java
+++ b/src/main/java/jenkins/plugins/office365connector/FactsBuilder.java
@@ -51,9 +51,6 @@ public class FactsBuilder {
 
     final static String NAME_FAILING_SINCE_BUILD = "Failing since";
 
-    // TODO: Running is not needed as it means same as Started
-    final static String VALUE_STATUS_RUNNING = "Running";
-
     private final List<Fact> facts = new ArrayList<>();
 
     private final Run run;
@@ -66,10 +63,6 @@ public class FactsBuilder {
 
     public void addStatus(String status) {
         addFact(NAME_STATUS, status);
-    }
-
-    public void addStatusRunning() {
-        addFact(NAME_STATUS, VALUE_STATUS_RUNNING);
     }
 
     public void addFailingSinceBuild(int buildNumber) {

--- a/src/test/java/jenkins/plugins/office365connector/CardBuilderTest.java
+++ b/src/test/java/jenkins/plugins/office365connector/CardBuilderTest.java
@@ -454,8 +454,7 @@ public class CardBuilderTest extends AbstractTest {
         assertThat(card.getSummary()).isEqualTo(JOB_DISPLAY_NAME + ": Build #" + BUILD_NUMBER);
         assertThat(card.getSections()).hasSize(1);
         assertThat(card.getThemeColor()).isEqualTo(color);
-        FactAssertion.assertThat(card.getSections().get(0).getFacts())
-                .hasName(FactsBuilder.NAME_STATUS).hasValue("Running");
+        assertThat(card.getSections().get(0).getFacts()).isEmpty();
     }
 
     @Test

--- a/src/test/java/jenkins/plugins/office365connector/FactsBuilderTest.java
+++ b/src/test/java/jenkins/plugins/office365connector/FactsBuilderTest.java
@@ -63,21 +63,6 @@ public class FactsBuilderTest extends AbstractTest {
     }
 
     @Test
-    public void addStatusRunning_AddsFact() {
-
-        // given
-        FactsBuilder factBuilder = new FactsBuilder(run, taskListener);
-
-        // when
-        factBuilder.addStatusRunning();
-
-        // then
-        FactAssertion.assertThat(factBuilder.collect())
-                .hasName(FactsBuilder.NAME_STATUS)
-                .hasValue(FactsBuilder.VALUE_STATUS_RUNNING);
-    }
-
-    @Test
     public void addFailingSinceBuild_AddsFact() {
 
         // given


### PR DESCRIPTION
As a proposal: As I hinted in #207 I think that "Status: Running" is just useless noise. This pull request drops this "default value" without replacement. A user can still specify `status: 'Running'` if she really thinks this information is valuable.