### PR TITLE
Remove unneeded buildPlugin config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,11 +2,4 @@
 
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
 
-buildPlugin(
-    findbugs: [
-        unstableTotalAll: '0'
-    ],
-    checkstyle: [
-        run: true
-    ]
-)
+buildPlugin()


### PR DESCRIPTION
Previous config not needed after https://github.com/jenkins-infra/pipeline-library/pull/121 is merged

Assumes that checkstyle and spotbugs run during the build