### PR TITLE
Update HttpWorker.java

### DIFF
--- a/src/main/java/jenkins/plugins/office365connector/HttpWorker.java
+++ b/src/main/java/jenkins/plugins/office365connector/HttpWorker.java
@@ -82,8 +82,8 @@ public class HttpWorker implements Runnable {
                 post.setRequestEntity(requestEntity);
                 int responseCode = client.executeMethod(post);
                 if (responseCode != HttpStatus.SC_OK) {
-                    String response = post.getResponseBodyAsString();
                     log("Posting data to %s may have failed. Webhook responded with status code - %s", url, responseCode);
+                    String response = post.getResponseBodyAsString();
                     log("Message from webhook - %s", response);
 
                 } else {


### PR DESCRIPTION
This is really tiny improvement, In my case getResponseBodyAsString is failing due to closed stream and in this case I am not able to see HTTP response code in logs to have an extra information for troubleshooting.