### PR TITLE
use GitHub urls instead of broken wiki links

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ job('Example Job Name') {
     // Webhook Macro Configuration
     configure {
         // Example: Conditioning webhook trigger on build parameter 'version' being equal to 'latest'
-        // Templates are defined as token macros https://wiki.jenkins.io/display/JENKINS/Token+Macro+Plugin
+        // Templates are defined as token macros https://github.com/jenkinsci/token-macro-plugin
         it / 'properties' / 'jenkins.plugins.office365connector.WebhookJobProperty' / 'webhooks' / 'jenkins.plugins.office365connector.Webhook' / 'macros' << 'jenkins.plugins.office365connector.model.Macro' {
           template('${ENV, var="version"}')
           value('latest')

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <version>4.15.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <description>This plugin sends Job notifications to JenkinsCI Office 365 Connector.</description>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Office+365+Connector+Plugin</url>
+    <url>https://github.com/jenkinsci/office-365-connector-plugin</url>
 
     <properties>
         <powermock.version>1.6.6</powermock.version>

--- a/src/main/java/jenkins/plugins/office365connector/ActionableBuilder.java
+++ b/src/main/java/jenkins/plugins/office365connector/ActionableBuilder.java
@@ -56,7 +56,7 @@ public class ActionableBuilder {
         potentialActions.add(new PotentialAction(viewHeader, urlToJob));
     }
 
-    // support for pull requests such as https://wiki.jenkins.io/display/JENKINS/GitHub+Branch+Source+Plugin
+    // support for pull requests such as https://github.com/jenkinsci/github-branch-source-plugin
     private void pullRequestActionable() {
         Job job = run.getParent();
         SCMHead head = SCMHead.HeadByItem.findHead(job);

--- a/src/main/resources/jenkins/plugins/office365connector/Webhook/help-factDefinitions.html
+++ b/src/main/resources/jenkins/plugins/office365connector/Webhook/help-factDefinitions.html
@@ -1,4 +1,4 @@
 <div align="help">
   Defines custom facts. Value can be written
-  as <a href="https://wiki.jenkins.io/display/JENKINS/Token+Macro+Plugin">token macro</a>
+  as <a href="https://github.com/jenkinsci/token-macro-plugin">token macro</a>
 </div>

--- a/src/main/resources/jenkins/plugins/office365connector/Webhook/help-macros.html
+++ b/src/main/resources/jenkins/plugins/office365connector/Webhook/help-macros.html
@@ -1,7 +1,7 @@
 <div align="help">
   Defines additional conditions that must be met to send the notification.
   It consists from pair of template and value. If template defined
-  as <a href="https://wiki.jenkins.io/display/JENKINS/Token+Macro+Plugin">token macro</a>
+  as <a href="https://github.com/jenkinsci/token-macro-plugin">token macro</a>
   is equal to value then the notification is sent. It is enough that one condition
   from this section is met.
   There are many plugins that support macros so filtering by Git event or build


### PR DESCRIPTION
Replaced all wiki links with the correct GitHub links. Since the Confluence is down and all information is at GitHub anyhow.
The only thing that might be of interest are the old changelogs: [wiki-dump](https://github.com/jenkins-infra/plugins-wiki-docs/tree/master/Office-365-Connector)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
