### PR TITLE
Implement no-proxy list in HttpWorker

### DIFF
--- a/src/test/java/jenkins/plugins/office365connector/HttpWorkerTest.java
+++ b/src/test/java/jenkins/plugins/office365connector/HttpWorkerTest.java
@@ -1,0 +1,93 @@
+package jenkins.plugins.office365connector;
+
+import hudson.ProxyConfiguration;
+import hudson.util.ReflectionUtils;
+import jenkins.model.Jenkins;
+import jenkins.plugins.office365connector.workflow.AbstractTest;
+import org.apache.commons.httpclient.HttpClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+
+@PowerMockIgnore("jdk.internal.reflect.*")
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Jenkins.class, HttpWorker.class})
+public class HttpWorkerTest extends AbstractTest {
+
+
+    @Before
+    public void setUp() {
+        Jenkins mockJenkins = mock(Jenkins.class);
+        mockStatic(Jenkins.class);
+        Mockito.when(Jenkins.get()).thenReturn(mockJenkins);
+    }
+
+    @Test
+    public void HttpWorker_getHttpClient_NoProxy() throws NoSuchMethodException {
+
+        // given
+        // from @Before
+        HttpWorker httpWorker = new HttpWorker("http://127.0.0.1", "{}", 30, System.out);
+        Method method = HttpWorker.class.getDeclaredMethod("getHttpClient");
+        method.setAccessible(true);
+
+        // when
+        HttpClient httpClient = (HttpClient) ReflectionUtils.invokeMethod(method, httpWorker);
+
+        // then
+        assertThat(httpClient.getHostConfiguration().getProxyHost()).isNull();
+        assertThat(httpClient.getHostConfiguration().getProxyPort()).isEqualTo(-1);
+    }
+
+    @Test
+    public void HttpWorker_getHttpClient_Proxy() throws NoSuchMethodException {
+
+        // given
+        // from @Before
+        Jenkins jenkins = Jenkins.get();
+        ProxyConfiguration proxyConfiguration = new ProxyConfiguration("name", 123, null, null, "*mockwebsite.com*");
+        jenkins.proxy = proxyConfiguration;
+
+        HttpWorker httpWorker = new HttpWorker("http://127.0.0.1", "{}", 30, System.out);
+        Method method = HttpWorker.class.getDeclaredMethod("getHttpClient");
+        method.setAccessible(true);
+
+        // when
+        HttpClient httpClient = (HttpClient) ReflectionUtils.invokeMethod(method, httpWorker);
+
+        // then
+        assertThat(httpClient.getHostConfiguration().getProxyHost()).isEqualTo(proxyConfiguration.getName());
+        assertThat(httpClient.getHostConfiguration().getProxyPort()).isEqualTo(proxyConfiguration.getPort());
+    }
+
+    @Test
+    public void HttpWorker_getHttpClient_Proxy_Ignored() throws NoSuchMethodException {
+
+        // given
+        // from @Before
+        Jenkins jenkins = Jenkins.get();
+        ProxyConfiguration proxyConfiguration = new ProxyConfiguration("name", 123, null, null, "*mockwebsite.com*");
+        jenkins.proxy = proxyConfiguration;
+
+        HttpWorker httpWorker = new HttpWorker("http://mockwebsite.com", "{}", 30, System.out);
+        Method method = HttpWorker.class.getDeclaredMethod("getHttpClient");
+        method.setAccessible(true);
+
+        // when
+        HttpClient httpClient = (HttpClient) ReflectionUtils.invokeMethod(method, httpWorker);
+
+        // then
+        assertThat(httpClient.getHostConfiguration().getProxyHost()).isNull();
+        assertThat(httpClient.getHostConfiguration().getProxyPort()).isEqualTo(-1);
+    }
+}


### PR DESCRIPTION
Hi,

I implemented respecting no-proxy list from `ProxyConfiguration` into the `HttpWorker` class.

Implementation to this point disregarded the no-proxy list when it comes to proxy usage in the `HttpWorker` class. This means that putting the used webhook domain into the Jenkins no-proxy list had no effect - webhook still tried to connect via proxy. In some use cases, this disqualified the plugin from use.

My implementation includes additional check before setting proxy. If the url matches some pattern on the no-proxy list, the proxy is not set.
https://github.com/jenkinsci/office-365-connector-plugin/blob/13c4482b5ac61f1863c5a7b1cbbe81c85221c0c0/src/main/java/jenkins/plugins/office365connector/HttpWorker.java#L111-L112

This fixes an issue https://github.com/jenkinsci/office-365-connector-plugin/issues/56 which was closed without a fix some time ago.


# How Has This Been Tested?

I wrote 3 tests to confirm that my change is working. I'm not familiar with Mockito framework, so feel free to refactor these tests, if deemed necessary.

- [x] `HttpWorker_getHttpClient_NoProxy`
https://github.com/jenkinsci/office-365-connector-plugin/blob/13c4482b5ac61f1863c5a7b1cbbe81c85221c0c0/src/test/java/jenkins/plugins/office365connector/HttpWorkerTest.java#L36
- [x] `HttpWorker_getHttpClient_Proxy`
https://github.com/jenkinsci/office-365-connector-plugin/blob/13c4482b5ac61f1863c5a7b1cbbe81c85221c0c0/src/test/java/jenkins/plugins/office365connector/HttpWorkerTest.java#L53
- [x] `HttpWorker_getHttpClient_Proxy_Ignored`
https://github.com/jenkinsci/office-365-connector-plugin/blob/13c4482b5ac61f1863c5a7b1cbbe81c85221c0c0/src/test/java/jenkins/plugins/office365connector/HttpWorkerTest.java#L74


