### PR TITLE
Option to disable 'Notification from ...' title

### DIFF
--- a/src/main/java/jenkins/plugins/office365connector/CardBuilder.java
+++ b/src/main/java/jenkins/plugins/office365connector/CardBuilder.java
@@ -181,8 +181,11 @@ public class CardBuilder {
             factsBuilder.addStatus(stepParameters.getStatus());
         }
         factsBuilder.addUserFacts(stepParameters.getFactDefinitions());
-
-        String activityTitle = "Notification from " + getEscapedDisplayName();
+        
+        if (stepParameters.getActivityTitle() == true) {
+            String activityTitle = "Notification from " + getEscapedDisplayName();
+        }
+        
         Section section = new Section(activityTitle, stepParameters.getMessage(), factsBuilder.collect());
 
         String summary = getDisplayName() + ": Build " + getRunName();

--- a/src/main/java/jenkins/plugins/office365connector/workflow/Execution.java
+++ b/src/main/java/jenkins/plugins/office365connector/workflow/Execution.java
@@ -21,7 +21,7 @@ public class Execution extends SynchronousNonBlockingStepExecution<Void> {
     public Execution(Office365ConnectorSendStep step, StepContext context) {
         super(context);
         stepParameters = new StepParameters(
-                step.getMessage(), step.getWebhookUrl(), step.getStatus(), step.getFactDefinitions(), step.getColor());
+                step.getMessage(), step.getWebhookUrl(), step.getStatus(), step.getFactDefinitions(), step.getColor(), step.getActivityTitle());
     }
 
     @Override

--- a/src/main/java/jenkins/plugins/office365connector/workflow/Office365ConnectorSendStep.java
+++ b/src/main/java/jenkins/plugins/office365connector/workflow/Office365ConnectorSendStep.java
@@ -63,7 +63,11 @@ public class Office365ConnectorSendStep extends Step {
     public String getColor() {
         return color;
     }
-
+    
+    public Boolean getActivityTitle() {
+        return activityTitle;
+    }
+    
     @DataBoundSetter
     public void setFactDefinitions(List<FactDefinition> factDefinitions) {
         this.factDefinitions = factDefinitions;

--- a/src/main/java/jenkins/plugins/office365connector/workflow/StepParameters.java
+++ b/src/main/java/jenkins/plugins/office365connector/workflow/StepParameters.java
@@ -29,13 +29,15 @@ public class StepParameters {
     private final String status;
     private final String color;
     private List<FactDefinition> factDefinitions;
-
+    private final Boolean activityTitle;
+    
     public StepParameters(String message, String webhookUrl, String status, List<FactDefinition> factDefinitions, String color) {
         this.message = message;
         this.webhookUrl = webhookUrl;
         this.status = status;
         this.factDefinitions = factDefinitions;
         this.color = color;
+        this.activityTitle = activityTitle;
     }
 
     public String getMessage() {
@@ -57,5 +59,8 @@ public class StepParameters {
     public String getColor() {
         return color;
     }
-
+    
+    public Boolean getActivityTitle() {
+        return activityTitle;
+    }
 }


### PR DESCRIPTION
Everytime a notification is posted to Teams through Jenkins, message has a bold first line starting with:
Notification from [path of jenkins job]

This PR would give the option to include this title or remove it