### PR TITLE
Updated maven-hpi-plugin to v3.27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
             <plugin>
                 <groupId>org.jenkins-ci.tools</groupId>
                 <artifactId>maven-hpi-plugin</artifactId>
-                <version>3.5</version>
+                <version>3.27</version>
                 <configuration>
                     <!-- Jenkins test InjectedTest renamed to InjectedIT so it is executed only during integration tests -->
                     <injectedTestName>InjectionIT</injectedTestName>


### PR DESCRIPTION
Update the maven-hpi-plugin to v3.27 to take advantage of later features.
v3.5 is over 3 years old and 

Tested by verifying that
- The project builds and the plugin works as intended
- All unit tests pass