### PR TITLE
EOL JSR 305

### DIFF
--- a/src/main/java/jenkins/plugins/office365connector/Webhook.java
+++ b/src/main/java/jenkins/plugins/office365connector/Webhook.java
@@ -16,7 +16,7 @@ package jenkins.plugins.office365connector;
 
 import java.util.Collections;
 import java.util.List;
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.AbstractDescribableImpl;
@@ -187,7 +187,7 @@ public class Webhook extends AbstractDescribableImpl<Webhook> {
             load();
         }
 
-        @Nonnull
+        @NonNull
         @Override
         public String getDisplayName() {
             return "Webhook";

--- a/src/main/java/jenkins/plugins/office365connector/model/FactDefinition.java
+++ b/src/main/java/jenkins/plugins/office365connector/model/FactDefinition.java
@@ -17,7 +17,7 @@ import hudson.Extension;
 import hudson.Util;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
@@ -65,7 +65,7 @@ public class FactDefinition extends AbstractDescribableImpl<FactDefinition> {
     @Extension
     public static class DescriptorImpl extends Descriptor<FactDefinition> {
 
-        @Nonnull
+        @NonNull
         @Override
         public String getDisplayName() {
             return "FactDefinition";

--- a/src/main/java/jenkins/plugins/office365connector/model/Macro.java
+++ b/src/main/java/jenkins/plugins/office365connector/model/Macro.java
@@ -13,7 +13,7 @@
  */
 package jenkins.plugins.office365connector.model;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import hudson.Extension;
 import hudson.Util;
@@ -55,7 +55,7 @@ public class Macro extends AbstractDescribableImpl<Macro> {
     @Extension
     public static class DescriptorImpl extends Descriptor<Macro> {
 
-        @Nonnull
+        @NonNull
         @Override
         public String getDisplayName() {
             return "Macro";

--- a/src/main/java/jenkins/plugins/office365connector/workflow/Office365ConnectorBuildListener.java
+++ b/src/main/java/jenkins/plugins/office365connector/workflow/Office365ConnectorBuildListener.java
@@ -4,7 +4,7 @@ import hudson.Extension;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import jenkins.plugins.office365connector.Office365ConnectorWebhookNotifier;
 
 /**
@@ -40,7 +40,7 @@ public class Office365ConnectorBuildListener extends RunListener<Run> {
      *                 operation.
      */
     @Override
-    public void onCompleted(Run run, @Nonnull TaskListener listener) {
+    public void onCompleted(Run run, @NonNull TaskListener listener) {
         Office365ConnectorWebhookNotifier notifier = new Office365ConnectorWebhookNotifier(run, listener);
         notifier.sendBuildCompletedNotification();
     }

--- a/src/main/java/jenkins/plugins/office365connector/workflow/Office365ConnectorSendStep.java
+++ b/src/main/java/jenkins/plugins/office365connector/workflow/Office365ConnectorSendStep.java
@@ -9,7 +9,7 @@ import hudson.Util;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.util.FormValidation;
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import jenkins.plugins.office365connector.model.FactDefinition;
 import jenkins.plugins.office365connector.utils.FormUtils;
 import org.jenkinsci.Symbol;
@@ -98,7 +98,7 @@ public class Office365ConnectorSendStep extends Step {
         }
 
         @Override
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return "Send job status notifications to Office 365 (e.g. Microsoft Teams or Outlook)";
         }


### PR DESCRIPTION
[`plugin-pom` 4.32](https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.32) dropped support of JSR 305 annotations in favor of SpotBugs annotations, so to be able to upgrade to 4.32 in the future we need to migrate from the deprecated usage to the non-deprecated equivalent. This PR matches dozens of PRs that I have (successfully) submitted to other Jenkins plugins.

CC @damianszczepanik