### PR TITLE
Remove Java 11 from build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [ '8', '11']
+        java: [ '8' ]
         os: [ 'ubuntu-latest', 'windows-latest', 'macos-latest' ]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 8
           distribution: adopt
 
       - name: Generate code coverage


### PR DESCRIPTION
Recent versions of PowerMock (which are needed for recent versions of the parent POM, which are needed for critical bug fixes) do not work on Java 11. Keep the build on Java 8 only until such a time as PowerMock references can be rewritten to use `mockito-inline` (which does work on Java 11). CC @damianszczepanik