### PR TITLE
Use Commons HttpClient 3.x API plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,11 @@
             <artifactId>commons-validator</artifactId>
             <version>1.7</version>
         </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-httpclient3-api</artifactId>
+            <version>3.1-3</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
The critical change that my previous PRs have been leading up to: stop depending on Commons HttpClient 3.x from core so that HttpClient 3.x can be removed from core. To implement this, there are two options:

- Depend on Commons HttpClient 3.x via a plugin-to-plugin dependency on `commons-httpclient3-api` (this PR)
- Depend on Commons HttpClient 4.x via a plugin-to-plugin dependency on `apache-httpcomponents-client-4-api` (#294)

This PR is low-risk because it is just changing linking but not changing the dependency version itself. However, version 3.x is deprecated and insecure, so if more risk is acceptable, then #294 is preferable.

CC @damianszczepanik