### PR TITLE
Accept more HTTP response codes

### DIFF
--- a/src/main/java/jenkins/plugins/office365connector/HttpWorker.java
+++ b/src/main/java/jenkins/plugins/office365connector/HttpWorker.java
@@ -84,7 +84,7 @@ public class HttpWorker implements Runnable {
 
             try (CloseableHttpResponse httpResponse = client.execute(post)) {
                 int responseCode = httpResponse.getStatusLine().getStatusCode();
-                if (responseCode != HttpStatus.SC_OK) {
+                if (responseCode >= HttpStatus.SC_BAD_REQUEST) {
                     log("Posting data to %s may have failed. Webhook responded with status code - %s", url, responseCode);
                     String response =
                             EntityUtils.toString(httpResponse.getEntity(), StandardCharsets.UTF_8);


### PR DESCRIPTION
Only consider HTTP response codes >= 400 as errors, avoiding unnecessary retries and potential duplicates

Fixes #356

Note: this is NOT a full fix for Microsoft's deprecation of Office 365 connectors for Teams, but is sufficient to allow use of powerautomation workflow to adapt the existing message content.

### Testing done

it compiles and passes existing unit tests

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

