### PR TITLE
Add example for Microsoft Teams notification using Adaptive Cards 📩

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,32 @@ pipeline {
 }
 ```
 
+### Pipeline post section with Adaptive Cards
+
+```groovy
+pipeline {
+
+    agent any
+
+    stages {
+        stage('Init') {
+            steps {
+                echo 'Hello!'
+            }
+        }
+    }
+
+    post {
+        failure {
+            office365ConnectorSend webhookUrl: "https://prod.westeurope.logic.azure.com:443/workflows...",
+              message: 'Something went wrong', 
+              status: 'Failure',
+              adaptiveCards: true
+        }
+    }
+}
+````
+
 ### Global Configuration in Init Hook
 
 Jenkins has the capability to execute Groovy scripts on launch by placing them in `$JENKINS_HOME/init.groovy.d`.


### PR DESCRIPTION
### Update README.md to include Microsoft Teams Notification Example Using Adaptive Cards

#### Summary
The `README.md` file has been updated to include a practical example of sending a notification to Microsoft Teams using **Adaptive Cards**, enabling users to quickly implement and customize their notifications.

#### Testing Performed
- **Manual Verification**: The new example was manually tested by running the notification code and verifying the expected output on Microsoft Teams.
  
> **Note**: Since this is a documentation update, no additional automated tests are included.

