### PR TITLE
Require Jenkins 2.479.1 and Jakarta EE 9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: adopt
 
       - run: mvn --batch-mode verify

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: adopt
 
       - name: Generate code coverage

--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.88</version>
+        <version>5.7</version>
         <relativePath />
     </parent>
 
     <licenses>
         <license>
             <name>The Apache Software License, Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
             <distribution>repo</distribution>
         </license>
     </licenses>
@@ -27,8 +27,8 @@
         <revision>5.0.1</revision>
         <changelist>-SNAPSHOT</changelist>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-        <jenkins.baseline>2.414</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+        <jenkins.baseline>2.479</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
 
         <gitHubRepo>jenkinsci/office-365-connector-plugin</gitHubRepo>
 
@@ -44,7 +44,7 @@
                      https://repo.jenkins-ci.org/artifactory/public/io/jenkins/tools/bom/
 				     https://www.jenkins.io/doc/developer/plugin-development/dependency-management/#jenkins-plugin-bom
 				-->
-                <version>2982.vdce2153031a_0</version>
+                <version>4051.v78dce3ce8b_d6</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -99,12 +99,6 @@
             <artifactId>commons-validator</artifactId>
             <version>1.7</version>
         </dependency>
-        <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>findbugs-annotations</artifactId>
-            <version>3.0.1</version>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
     <build>
@@ -143,14 +137,14 @@
             <name>Out conn</name>
             <email>outconn@microsoft.com</email>
             <organization>Microsoft Corp.</organization>
-            <organizationUrl>http://microsoft.com</organizationUrl>
+            <organizationUrl>https://microsoft.com</organizationUrl>
         </developer>
         <developer>
             <id>srhebbar</id>
             <name>Srivardhan Hebbar</name>
             <email>srhebbar@microsoft.com</email>
             <organization>Microsoft Corp.</organization>
-            <organizationUrl>http://microsoft.com</organizationUrl>
+            <organizationUrl>https://microsoft.com</organizationUrl>
         </developer>
     </developers>
 

--- a/src/main/java/jenkins/plugins/office365connector/FactsBuilder.java
+++ b/src/main/java/jenkins/plugins/office365connector/FactsBuilder.java
@@ -80,10 +80,9 @@ public class FactsBuilder {
     }
 
     public void addCommitters() {
-        if (!(run instanceof RunWithSCM)) {
+        if (!(run instanceof RunWithSCM runWithSCM)) {
             return;
         }
-        RunWithSCM runWithSCM = (RunWithSCM) run;
         Set<User> authors = runWithSCM.getCulprits();
 
         String joinedCommitters = authors.stream()
@@ -93,10 +92,9 @@ public class FactsBuilder {
     }
 
     public void addDevelopers() {
-        if (!(run instanceof RunWithSCM)) {
+        if (!(run instanceof RunWithSCM runWithSCM)) {
             return;
         }
-        RunWithSCM runWithSCM = (RunWithSCM) run;
 
         List<ChangeLogSet<ChangeLogSet.Entry>> sets = runWithSCM.getChangeSets();
 

--- a/src/main/java/jenkins/plugins/office365connector/HttpWorker.java
+++ b/src/main/java/jenkins/plugins/office365connector/HttpWorker.java
@@ -111,7 +111,7 @@ public class HttpWorker implements Runnable {
                 if (!isNoProxyHost(this.url, noHostProxyPatterns)) {
                     builder.setProxy(new HttpHost(proxy.name, proxy.port));
                     String username = proxy.getUserName();
-                    String password = proxy.getPassword();
+                    String password = proxy.getSecretPassword().getPlainText();
                     // Consider it to be passed if username specified. Sufficient?
                     if (StringUtils.isNotBlank(username)) {
                         CredentialsProvider credsProvider = new BasicCredentialsProvider();

--- a/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
+++ b/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
@@ -112,7 +112,7 @@ public class Office365ConnectorWebhookNotifier {
     private void executeWorker(Webhook webhook, Card card) {
         try {
             String url = run.getEnvironment(taskListener).expand(webhook.getUrl());
-            String data = gson.toJson(card == null ? null : card.toPaylod());
+            String data = gson.toJson(card == null ? null : card.toPayload());
             HttpWorker worker = new HttpWorker(url, data, webhook.getTimeout(), taskListener.getLogger());
             worker.submit();
         } catch (IOException | InterruptedException | RejectedExecutionException e) {

--- a/src/main/java/jenkins/plugins/office365connector/Webhook.java
+++ b/src/main/java/jenkins/plugins/office365connector/Webhook.java
@@ -31,7 +31,7 @@ import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 public class Webhook extends AbstractDescribableImpl<Webhook> {
 
@@ -258,7 +258,7 @@ public class Webhook extends AbstractDescribableImpl<Webhook> {
         }
 
         @Override
-        public boolean configure(StaplerRequest req, JSONObject formData) {
+        public boolean configure(StaplerRequest2 req, JSONObject formData) {
             req.bindJSON(this, formData);
             save();
             return true;

--- a/src/main/java/jenkins/plugins/office365connector/WebhookJobPropertyDescriptor.java
+++ b/src/main/java/jenkins/plugins/office365connector/WebhookJobPropertyDescriptor.java
@@ -23,7 +23,7 @@ import net.sf.json.JSON;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 @Extension
 @Symbol("office365ConnectorWebhooks")
@@ -56,7 +56,7 @@ public final class WebhookJobPropertyDescriptor extends JobPropertyDescriptor {
     }
 
     @Override
-    public WebhookJobProperty newInstance(StaplerRequest req, JSONObject formData) {
+    public WebhookJobProperty newInstance(StaplerRequest2 req, JSONObject formData) {
 
         List<Webhook> webhooks = new ArrayList<>();
         if (formData != null && !formData.isNullObject()) {
@@ -75,7 +75,7 @@ public final class WebhookJobPropertyDescriptor extends JobPropertyDescriptor {
     }
 
     @Override
-    public boolean configure(StaplerRequest req, JSONObject formData) {
+    public boolean configure(StaplerRequest2 req, JSONObject formData) {
         save();
         return true;
     }

--- a/src/main/java/jenkins/plugins/office365connector/model/Card.java
+++ b/src/main/java/jenkins/plugins/office365connector/model/Card.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 public interface Card {
 
-    public Object toPaylod();
+    Object toPayload();
 
     void setAction(List<CardAction> actions);
 

--- a/src/main/java/jenkins/plugins/office365connector/model/Fact.java
+++ b/src/main/java/jenkins/plugins/office365connector/model/Fact.java
@@ -2,9 +2,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/jenkins/plugins/office365connector/model/adaptivecard/AdaptiveCard.java
+++ b/src/main/java/jenkins/plugins/office365connector/model/adaptivecard/AdaptiveCard.java
@@ -73,7 +73,7 @@ public class AdaptiveCard implements Card {
     }
 
     @Override
-    public Object toPaylod() {
+    public Object toPayload() {
         return new Payload(this);
     }
 

--- a/src/main/java/jenkins/plugins/office365connector/model/messagecard/MessageCard.java
+++ b/src/main/java/jenkins/plugins/office365connector/model/messagecard/MessageCard.java
@@ -64,7 +64,7 @@ public class MessageCard implements Card {
     }
 
     @Override
-    public Object toPaylod() {
+    public Object toPayload() {
         return this;
     }
 }

--- a/src/main/java/jenkins/plugins/office365connector/workflow/Execution.java
+++ b/src/main/java/jenkins/plugins/office365connector/workflow/Execution.java
@@ -2,6 +2,7 @@ package jenkins.plugins.office365connector.workflow;
 
 
 import java.io.IOException;
+import java.io.Serial;
 
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -14,6 +15,7 @@ import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
  */
 public class Execution extends SynchronousNonBlockingStepExecution<Void> {
 
+    @Serial
     private static final long serialVersionUID = 8433805238008188090L;
 
     private transient final StepParameters stepParameters;

--- a/src/test/java/jenkins/plugins/office365connector/WebhookDescriptorImplTest.java
+++ b/src/test/java/jenkins/plugins/office365connector/WebhookDescriptorImplTest.java
@@ -13,7 +13,7 @@ import jenkins.model.Jenkins;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 import org.mockito.MockedStatic;
 
 /**
@@ -102,7 +102,7 @@ public class WebhookDescriptorImplTest {
     public void configure_ReturnsTrue() {
 
         // given
-        StaplerRequest staplerRequest = mock(StaplerRequest.class);
+        StaplerRequest2 staplerRequest = mock(StaplerRequest2.class);
         when(staplerRequest.bindJSON(any(), any())).thenReturn("");
 
         // when

--- a/src/test/java/jenkins/plugins/office365connector/helpers/AffectedFileBuilder.java
+++ b/src/test/java/jenkins/plugins/office365connector/helpers/AffectedFileBuilder.java
@@ -60,7 +60,7 @@ public class AffectedFileBuilder {
         return (invocation -> value);
     }
 
-    private class File implements ChangeLogSet.AffectedFile {
+    private static class File implements ChangeLogSet.AffectedFile {
 
         @Override
         public String getPath() {

--- a/src/test/java/jenkins/plugins/office365connector/workflow/AdaptiveCardIT.java
+++ b/src/test/java/jenkins/plugins/office365connector/workflow/AdaptiveCardIT.java
@@ -1,6 +1,5 @@
 package jenkins.plugins.office365connector.workflow;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/jenkins/plugins/office365connector/workflow/PullRequestIT.java
+++ b/src/test/java/jenkins/plugins/office365connector/workflow/PullRequestIT.java
@@ -4,7 +4,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;

--- a/src/test/java/jenkins/plugins/office365connector/workflow/WebhookJobPropertyDescriptorTest.java
+++ b/src/test/java/jenkins/plugins/office365connector/workflow/WebhookJobPropertyDescriptorTest.java
@@ -22,7 +22,7 @@ import net.sf.json.JsonConfig;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 import org.mockito.ArgumentMatchers;
 import org.mockito.MockedStatic;
 
@@ -119,7 +119,7 @@ public class WebhookJobPropertyDescriptorTest {
         WebhookJobPropertyDescriptor descriptor = new WebhookJobPropertyDescriptor();
 
         // when
-        WebhookJobProperty property = descriptor.newInstance(null, null);
+        WebhookJobProperty property = descriptor.newInstance((StaplerRequest2) null, null);
 
         // then
         assertThat(property).isNotNull();
@@ -134,7 +134,7 @@ public class WebhookJobPropertyDescriptorTest {
         JSONObject jsonObject = new JSONObject(true);
 
         // when
-        WebhookJobProperty property = descriptor.newInstance(null, jsonObject);
+        WebhookJobProperty property = descriptor.newInstance((StaplerRequest2) null, jsonObject);
 
         // then
         assertThat(property).isNotNull();
@@ -149,7 +149,7 @@ public class WebhookJobPropertyDescriptorTest {
         JSONObject jsonObject = new JSONObject();
 
         // when
-        WebhookJobProperty property = descriptor.newInstance(null, jsonObject);
+        WebhookJobProperty property = descriptor.newInstance((StaplerRequest2) null, jsonObject);
 
         // then
         assertThat(property).isNotNull();
@@ -165,7 +165,7 @@ public class WebhookJobPropertyDescriptorTest {
         jsonObject.put(KEY, Collections.emptyList());
 
         // when
-        WebhookJobProperty property = descriptor.newInstance(null, jsonObject);
+        WebhookJobProperty property = descriptor.newInstance((StaplerRequest2) null, jsonObject);
 
         // then
         assertThat(property).isNotNull();
@@ -181,14 +181,14 @@ public class WebhookJobPropertyDescriptorTest {
         Webhook webhook = new Webhook("myUrl");
 
         // Excluding "descriptor" to avoid infinite loop in jsonObject.put()
-        Map map = new HashMap<String, Object>();
+        Map<String, Object> map = new HashMap<>();
         map.put(KEY, webhook);
         JsonConfig config = new JsonConfig();
         config.setExcludes(new String[]{"descriptor"});
 
         jsonObject.putAll(map, config);
 
-        StaplerRequest request = mock(StaplerRequest.class);
+        StaplerRequest2 request = mock(StaplerRequest2.class);
         when(request.bindJSON(ArgumentMatchers.any(), (JSONObject) ArgumentMatchers.eq(jsonObject.get(KEY)))).thenReturn(webhook);
 
         // when
@@ -209,14 +209,14 @@ public class WebhookJobPropertyDescriptorTest {
         List<Object> webhooks = Arrays.asList(webhook);
 
         // Excluding "descriptor" to avoid infinite loop in jsonObject.put()
-        Map map = new HashMap<String, Object>();
+        Map<String, Object> map = new HashMap<>();
         map.put(KEY, webhooks);
         JsonConfig config = new JsonConfig();
         config.setExcludes(new String[]{"descriptor"});
 
         jsonObject.putAll(map, config);
 
-        StaplerRequest request = mock(StaplerRequest.class);
+        StaplerRequest2 request = mock(StaplerRequest2.class);
         when(request.bindJSONToList(ArgumentMatchers.any(), ArgumentMatchers.eq(jsonObject.get(KEY)))).thenReturn(webhooks);
 
         // when
@@ -236,7 +236,7 @@ public class WebhookJobPropertyDescriptorTest {
         WebhookJobPropertyDescriptor descriptor = new WebhookJobPropertyDescriptor();
 
         // when
-        boolean isConfigured = descriptor.configure(null, null);
+        boolean isConfigured = descriptor.configure((StaplerRequest2) null, null);
 
         // then
         // very naive, worth to improve


### PR DESCRIPTION
## Require Jenkins 2.479.1 and Jakarta EE 9

Jenkins 2.479.1 provides Jakarta EE 9, Eclipse Jetty 12, Spring Security 6, and Java 17.

* Update plugin pom and baseline
* Remove deprecations
* Use Java 17 language features

### Testing done

Confirmed that tests pass.

### Submitter checklist
* [x]  Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
* [x]  Ensure that the pull request title represents the desired changelog entry
* [x]  Please describe what you did
* [x]  Link to relevant issues in GitHub or Jira
* [x]  Link to relevant pull requests, esp. upstream and downstream changes
* [x]  Ensure you have provided tests - that demonstrates feature works or fixes the issue
