### PR TITLE
Migrate from EE 8 to EE 9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
-          java-version: 11
-          distribution: adopt
+          java-version: 21
+          distribution: temurin
 
       - run: mvn --batch-mode verify

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
-          java-version: 11
-          distribution: adopt
+          java-version: 21
+          distribution: temurin
 
       - name: Generate code coverage
         run: mvn --batch-mode test

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.88</version>
+        <version>5.7</version>
         <relativePath />
     </parent>
 
@@ -27,8 +27,8 @@
         <revision>5.0.1</revision>
         <changelist>-SNAPSHOT</changelist>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-        <jenkins.baseline>2.414</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+        <jenkins.baseline>2.479</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
 
         <gitHubRepo>jenkinsci/office-365-connector-plugin</gitHubRepo>
 
@@ -44,7 +44,7 @@
                      https://repo.jenkins-ci.org/artifactory/public/io/jenkins/tools/bom/
 				     https://www.jenkins.io/doc/developer/plugin-development/dependency-management/#jenkins-plugin-bom
 				-->
-                <version>2982.vdce2153031a_0</version>
+                <version>3893.v213a_42768d35</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
-            <version>1.7</version>
+            <version>1.9.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>

--- a/src/main/java/jenkins/plugins/office365connector/Webhook.java
+++ b/src/main/java/jenkins/plugins/office365connector/Webhook.java
@@ -31,7 +31,7 @@ import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 public class Webhook extends AbstractDescribableImpl<Webhook> {
 
@@ -258,7 +258,7 @@ public class Webhook extends AbstractDescribableImpl<Webhook> {
         }
 
         @Override
-        public boolean configure(StaplerRequest req, JSONObject formData) {
+        public boolean configure(StaplerRequest2 req, JSONObject formData) {
             req.bindJSON(this, formData);
             save();
             return true;

--- a/src/main/java/jenkins/plugins/office365connector/WebhookJobPropertyDescriptor.java
+++ b/src/main/java/jenkins/plugins/office365connector/WebhookJobPropertyDescriptor.java
@@ -23,7 +23,7 @@ import net.sf.json.JSON;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 @Extension
 @Symbol("office365ConnectorWebhooks")
@@ -56,7 +56,7 @@ public final class WebhookJobPropertyDescriptor extends JobPropertyDescriptor {
     }
 
     @Override
-    public WebhookJobProperty newInstance(StaplerRequest req, JSONObject formData) {
+    public WebhookJobProperty newInstance(StaplerRequest2 req, JSONObject formData) {
 
         List<Webhook> webhooks = new ArrayList<>();
         if (formData != null && !formData.isNullObject()) {
@@ -75,7 +75,7 @@ public final class WebhookJobPropertyDescriptor extends JobPropertyDescriptor {
     }
 
     @Override
-    public boolean configure(StaplerRequest req, JSONObject formData) {
+    public boolean configure(StaplerRequest2 req, JSONObject formData) {
         save();
         return true;
     }

--- a/src/test/java/jenkins/plugins/office365connector/WebhookDescriptorImplTest.java
+++ b/src/test/java/jenkins/plugins/office365connector/WebhookDescriptorImplTest.java
@@ -13,7 +13,7 @@ import jenkins.model.Jenkins;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 import org.mockito.MockedStatic;
 
 /**
@@ -102,7 +102,7 @@ public class WebhookDescriptorImplTest {
     public void configure_ReturnsTrue() {
 
         // given
-        StaplerRequest staplerRequest = mock(StaplerRequest.class);
+        StaplerRequest2 staplerRequest = mock(StaplerRequest2.class);
         when(staplerRequest.bindJSON(any(), any())).thenReturn("");
 
         // when

--- a/src/test/java/jenkins/plugins/office365connector/workflow/WebhookJobPropertyDescriptorTest.java
+++ b/src/test/java/jenkins/plugins/office365connector/workflow/WebhookJobPropertyDescriptorTest.java
@@ -22,7 +22,7 @@ import net.sf.json.JsonConfig;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 import org.mockito.ArgumentMatchers;
 import org.mockito.MockedStatic;
 
@@ -119,7 +119,7 @@ public class WebhookJobPropertyDescriptorTest {
         WebhookJobPropertyDescriptor descriptor = new WebhookJobPropertyDescriptor();
 
         // when
-        WebhookJobProperty property = descriptor.newInstance(null, null);
+        WebhookJobProperty property = descriptor.newInstance((StaplerRequest2) null, null);
 
         // then
         assertThat(property).isNotNull();
@@ -134,7 +134,7 @@ public class WebhookJobPropertyDescriptorTest {
         JSONObject jsonObject = new JSONObject(true);
 
         // when
-        WebhookJobProperty property = descriptor.newInstance(null, jsonObject);
+        WebhookJobProperty property = descriptor.newInstance((StaplerRequest2) null, jsonObject);
 
         // then
         assertThat(property).isNotNull();
@@ -149,7 +149,7 @@ public class WebhookJobPropertyDescriptorTest {
         JSONObject jsonObject = new JSONObject();
 
         // when
-        WebhookJobProperty property = descriptor.newInstance(null, jsonObject);
+        WebhookJobProperty property = descriptor.newInstance((StaplerRequest2) null, jsonObject);
 
         // then
         assertThat(property).isNotNull();
@@ -165,7 +165,7 @@ public class WebhookJobPropertyDescriptorTest {
         jsonObject.put(KEY, Collections.emptyList());
 
         // when
-        WebhookJobProperty property = descriptor.newInstance(null, jsonObject);
+        WebhookJobProperty property = descriptor.newInstance((StaplerRequest2) null, jsonObject);
 
         // then
         assertThat(property).isNotNull();
@@ -188,7 +188,7 @@ public class WebhookJobPropertyDescriptorTest {
 
         jsonObject.putAll(map, config);
 
-        StaplerRequest request = mock(StaplerRequest.class);
+        StaplerRequest2 request = mock(StaplerRequest2.class);
         when(request.bindJSON(ArgumentMatchers.any(), (JSONObject) ArgumentMatchers.eq(jsonObject.get(KEY)))).thenReturn(webhook);
 
         // when
@@ -216,7 +216,7 @@ public class WebhookJobPropertyDescriptorTest {
 
         jsonObject.putAll(map, config);
 
-        StaplerRequest request = mock(StaplerRequest.class);
+        StaplerRequest2 request = mock(StaplerRequest2.class);
         when(request.bindJSONToList(ArgumentMatchers.any(), ArgumentMatchers.eq(jsonObject.get(KEY)))).thenReturn(webhooks);
 
         // when
@@ -236,7 +236,7 @@ public class WebhookJobPropertyDescriptorTest {
         WebhookJobPropertyDescriptor descriptor = new WebhookJobPropertyDescriptor();
 
         // when
-        boolean isConfigured = descriptor.configure(null, null);
+        boolean isConfigured = descriptor.configure((StaplerRequest2) null, null);
 
         // then
         // very naive, worth to improve


### PR DESCRIPTION
Migrate from deprecated EE 8 methods to non-deprecated EE 9 equivalents.

### Testing done

`mvn clean verify`