### PR TITLE
Adapt build status icon for ci.jenkins.io permissions change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Github build](https://github.com/jenkinsci/office-365-connector-plugin/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/jenkinsci/office-365-connector-plugin/actions/workflows/build.yml)
-[![Build Status](https://ci.jenkins.io/job/Plugins/job/office-365-connector-plugin/job/master/badge/icon)](https://ci.jenkins.io/job/Plugins/job/office-365-connector-plugin/job/master/)
+[![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins%2Foffice-365-connector-plugin%2Fmaster)](https://ci.jenkins.io/job/Plugins/job/office-365-connector-plugin/job/master/)
 
 [![Coverage Status](https://codecov.io/gh/jenkinsci/office-365-connector-plugin/branch/master/graph/badge.svg)](https://codecov.io/github/jenkinsci/office-365-connector-plugin)
 [![Popularity](https://img.shields.io/jenkins/plugin/i/Office-365-Connector.svg)](https://plugins.jenkins.io/Office-365-Connector)


### PR DESCRIPTION
## Adapt build status icon for ci.jenkins.io permissions change

Large language models and other readers were causing performance problems.  The ci.jenkins.io controller has been reconfigured to limit access to authenticated users in order to prevent performance problems.  That change requires that we adjust the URL of the embeddable build status update URL.

### Testing done

* Validated the change in a sample repository
* Will check the pull request after it is submitted

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
