### PR TITLE
Added support for user mentions when posting a message

### DIFF
--- a/src/main/java/jenkins/plugins/office365connector/CardBuilder.java
+++ b/src/main/java/jenkins/plugins/office365connector/CardBuilder.java
@@ -20,6 +20,7 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import jenkins.plugins.office365connector.model.Card;
 import jenkins.plugins.office365connector.model.FactDefinition;
+import jenkins.plugins.office365connector.model.Mention;
 import jenkins.plugins.office365connector.model.Section;
 import jenkins.plugins.office365connector.model.adaptivecard.AdaptiveCard;
 import jenkins.plugins.office365connector.model.messagecard.MessageCard;
@@ -45,6 +46,10 @@ public class CardBuilder {
     }
 
     public Card createStartedCard(List<FactDefinition> factDefinitions) {
+        return createStartedCard(factDefinitions, List.of());
+    }
+
+    public Card createStartedCard(List<FactDefinition> factDefinitions, List<Mention> mentions) {
         final String statusName = "Started";
         factsBuilder.addStatus(statusName);
         factsBuilder.addRemarks();
@@ -55,13 +60,17 @@ public class CardBuilder {
         Section section = buildSection(statusName);
 
         String summary = getDisplayName() + ": Build " + getRunName();
-        Card card = isAdaptiveCards ? new AdaptiveCard(summary, section, getCompletedResult(run)) : new MessageCard(summary, section);
+        Card card = isAdaptiveCards ? new AdaptiveCard(summary, section, getCompletedResult(run), mentions) : new MessageCard(summary, section);
         card.setAction(potentialActionBuilder.buildActionable());
 
         return card;
     }
 
     public Card createCompletedCard(List<FactDefinition> factDefinitions) {
+        return createCompletedCard(factDefinitions, List.of());
+    }
+
+    public Card createCompletedCard(List<FactDefinition> factDefinitions, List<Mention> mentions) {
         // result might be null only for ongoing job - check documentation of Run.getCompletedResult()
         // but based on issue #133 it may happen that result for completed job is null
         Result lastResult = getCompletedResult(run);
@@ -90,7 +99,7 @@ public class CardBuilder {
 
         Section section = buildSection(status);
 
-        Card card = isAdaptiveCards ? new AdaptiveCard(summary, section, getCompletedResult(run)) : new MessageCard(summary, section);
+        Card card = isAdaptiveCards ? new AdaptiveCard(summary, section, getCompletedResult(run), mentions) : new MessageCard(summary, section);
         card.setThemeColor(getCardThemeColor(lastResult));
         if (run.getResult() != Result.SUCCESS) {
             card.setAction(potentialActionBuilder.buildActionable());
@@ -192,7 +201,8 @@ public class CardBuilder {
         Section section = new Section(activityTitle, stepParameters.getMessage(), factsBuilder.collect());
 
         String summary = getDisplayName() + ": Build " + getRunName();
-        Card card = isAdaptiveCards ? new AdaptiveCard(summary, section, getCompletedResult(run)) : new MessageCard(summary, section);
+        List<Mention> mentions = stepParameters.getMentions() != null ? stepParameters.getMentions() : List.of();
+        Card card = isAdaptiveCards ? new AdaptiveCard(summary, section, getCompletedResult(run), mentions) : new MessageCard(summary, section);
 
         if (stepParameters.getColor() != null) {
             card.setThemeColor(stepParameters.getColor());

--- a/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
+++ b/src/main/java/jenkins/plugins/office365connector/Office365ConnectorWebhookNotifier.java
@@ -62,7 +62,7 @@ public class Office365ConnectorWebhookNotifier {
                 if (decisionMaker.isAtLeastOneRuleMatched(webhook)) {
                     if (webhook.isStartNotification()) {
                         CardBuilder cardBuilder = new CardBuilder(run, taskListener, webhook.isAdaptiveCards());
-                        Card card = cardBuilder.createStartedCard(webhook.getFactDefinitions());
+                        Card card = cardBuilder.createStartedCard(webhook.getFactDefinitions(), webhook.getMentions());
                         executeWorker(webhook, card);
                     }
                 }
@@ -77,7 +77,7 @@ public class Office365ConnectorWebhookNotifier {
             if (decisionMaker.isAtLeastOneRuleMatched(webhook)) {
                 if (decisionMaker.isStatusMatched(webhook)) {
                     CardBuilder cardBuilder = new CardBuilder(run, taskListener, webhook.isAdaptiveCards());
-                    Card card = cardBuilder.createCompletedCard(webhook.getFactDefinitions());
+                    Card card = cardBuilder.createCompletedCard(webhook.getFactDefinitions(), webhook.getMentions());
                     executeWorker(webhook, card);
                 }
             }
@@ -113,6 +113,7 @@ public class Office365ConnectorWebhookNotifier {
         try {
             String url = run.getEnvironment(taskListener).expand(webhook.getUrl());
             String data = gson.toJson(card == null ? null : card.toPaylod());
+            log("Sending payload to " + url + ":\n" + data);
             HttpWorker worker = new HttpWorker(url, data, webhook.getTimeout(), taskListener.getLogger());
             worker.submit();
         } catch (IOException | InterruptedException | RejectedExecutionException e) {

--- a/src/main/java/jenkins/plugins/office365connector/Webhook.java
+++ b/src/main/java/jenkins/plugins/office365connector/Webhook.java
@@ -25,6 +25,7 @@ import hudson.model.Descriptor;
 import hudson.util.FormValidation;
 import jenkins.plugins.office365connector.model.FactDefinition;
 import jenkins.plugins.office365connector.model.Macro;
+import jenkins.plugins.office365connector.model.Mention;
 import jenkins.plugins.office365connector.utils.FormUtils;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang3.StringUtils;
@@ -56,6 +57,8 @@ public class Webhook extends AbstractDescribableImpl<Webhook> {
     private List<Macro> macros = Collections.emptyList();
 
     private List<FactDefinition> factDefinitions = Collections.emptyList();
+
+    private List<Mention> mentions = Collections.emptyList();
 
     @Override
     public DescriptorImpl getDescriptor() {
@@ -186,6 +189,15 @@ public class Webhook extends AbstractDescribableImpl<Webhook> {
     @DataBoundSetter
     public void setFactDefinitions(List<FactDefinition> factDefinitions) {
         this.factDefinitions = Util.fixNull(factDefinitions);
+    }
+
+    public List<Mention> getMentions() {
+        return Util.fixNull(mentions);
+    }
+
+    @DataBoundSetter
+    public void setMentions(List<Mention> mentions) {
+        this.mentions = Util.fixNull(mentions);
     }
 
     @Extension

--- a/src/main/java/jenkins/plugins/office365connector/model/Mention.java
+++ b/src/main/java/jenkins/plugins/office365connector/model/Mention.java
@@ -1,0 +1,52 @@
+package jenkins.plugins.office365connector.model;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.Util;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+/**
+ * Defines a user to mention in an Adaptive Card notification.
+ */
+public class Mention extends AbstractDescribableImpl<Mention> {
+
+    private String userId;
+    private String name;
+
+    @DataBoundConstructor
+    public Mention(String userId, String name) {
+        this.userId = Util.fixNull(userId);
+        this.name = Util.fixNull(name);
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    @DataBoundSetter
+    public void setUserId(String userId) {
+        this.userId = Util.fixNull(userId);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @DataBoundSetter
+    public void setName(String name) {
+        this.name = Util.fixNull(name);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<Mention> {
+
+        @NonNull
+        @Override
+        public String getDisplayName() {
+            return "Mention";
+        }
+    }
+}

--- a/src/main/java/jenkins/plugins/office365connector/model/adaptivecard/AdaptiveCard.java
+++ b/src/main/java/jenkins/plugins/office365connector/model/adaptivecard/AdaptiveCard.java
@@ -2,12 +2,14 @@ package jenkins.plugins.office365connector.model.adaptivecard;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.google.gson.annotations.SerializedName;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.Result;
 import jenkins.plugins.office365connector.model.Card;
 import jenkins.plugins.office365connector.model.CardAction;
+import jenkins.plugins.office365connector.model.Mention;
 import jenkins.plugins.office365connector.model.Section;
 
 public class AdaptiveCard implements Card {
@@ -23,6 +25,10 @@ public class AdaptiveCard implements Card {
     private List<CardAction> actions;
 
     public AdaptiveCard(final String summary, final Section section, Result result) {
+        this(summary, section, result, List.of());
+    }
+
+    public AdaptiveCard(final String summary, final Section section, Result result, List<Mention> mentions) {
         this.body = new ArrayList<>();
         this.body.add(new TextBlock(summary, "large", "bolder", color(result)));
         if (section != null) {
@@ -33,6 +39,16 @@ public class AdaptiveCard implements Card {
             if (!section.getFacts().isEmpty()) {
                 this.body.add(new FactSet(section.getFacts()));
             }
+        }
+        if (mentions != null && !mentions.isEmpty()) {
+            List<MentionEntity> entities = mentions.stream()
+                    .map(MentionEntity::new)
+                    .collect(Collectors.toList());
+            msTeams.setEntities(entities);
+            String mentionText = entities.stream()
+                    .map(MentionEntity::getText)
+                    .collect(Collectors.joining(" "));
+            this.body.add(new TextBlock(mentionText));
         }
     }
 

--- a/src/main/java/jenkins/plugins/office365connector/model/adaptivecard/MentionEntity.java
+++ b/src/main/java/jenkins/plugins/office365connector/model/adaptivecard/MentionEntity.java
@@ -1,0 +1,27 @@
+package jenkins.plugins.office365connector.model.adaptivecard;
+
+import jenkins.plugins.office365connector.model.Mention;
+
+public class MentionEntity {
+
+    private final String type = "mention";
+    private final String text;
+    private final Mentioned mentioned;
+
+    public MentionEntity(Mention mention) {
+        this.text = "<at>" + mention.getName() + "</at>";
+        this.mentioned = new Mentioned(mention.getUserId(), mention.getName());
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public Mentioned getMentioned() {
+        return mentioned;
+    }
+}

--- a/src/main/java/jenkins/plugins/office365connector/model/adaptivecard/MentionEntity.java
+++ b/src/main/java/jenkins/plugins/office365connector/model/adaptivecard/MentionEntity.java
@@ -1,9 +1,11 @@
 package jenkins.plugins.office365connector.model.adaptivecard;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jenkins.plugins.office365connector.model.Mention;
 
 public class MentionEntity {
 
+    @SuppressFBWarnings(value = "SS_SHOULD_BE_STATIC")
     private final String type = "mention";
     private final String text;
     private final Mentioned mentioned;

--- a/src/main/java/jenkins/plugins/office365connector/model/adaptivecard/Mentioned.java
+++ b/src/main/java/jenkins/plugins/office365connector/model/adaptivecard/Mentioned.java
@@ -1,0 +1,20 @@
+package jenkins.plugins.office365connector.model.adaptivecard;
+
+public class Mentioned {
+
+    private final String id;
+    private final String name;
+
+    public Mentioned(String id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/jenkins/plugins/office365connector/model/adaptivecard/MsTeams.java
+++ b/src/main/java/jenkins/plugins/office365connector/model/adaptivecard/MsTeams.java
@@ -1,10 +1,21 @@
 package jenkins.plugins.office365connector.model.adaptivecard;
 
+import java.util.List;
+
 public class MsTeams {
 
     private String width = "Full";
+    private List<MentionEntity> entities;
 
     public String getWidth() {
         return width;
+    }
+
+    public List<MentionEntity> getEntities() {
+        return entities;
+    }
+
+    public void setEntities(List<MentionEntity> entities) {
+        this.entities = entities;
     }
 }

--- a/src/main/java/jenkins/plugins/office365connector/workflow/Execution.java
+++ b/src/main/java/jenkins/plugins/office365connector/workflow/Execution.java
@@ -21,7 +21,7 @@ public class Execution extends SynchronousNonBlockingStepExecution<Void> {
     public Execution(Office365ConnectorSendStep step, StepContext context) {
         super(context);
         stepParameters = new StepParameters(
-                step.getMessage(), step.getWebhookUrl(), step.getStatus(), step.getFactDefinitions(), step.getColor(), step.isAdaptiveCards());
+                step.getMessage(), step.getWebhookUrl(), step.getStatus(), step.getFactDefinitions(), step.getColor(), step.isAdaptiveCards(), step.getMentions());
     }
 
     @Override

--- a/src/main/java/jenkins/plugins/office365connector/workflow/Office365ConnectorSendStep.java
+++ b/src/main/java/jenkins/plugins/office365connector/workflow/Office365ConnectorSendStep.java
@@ -11,6 +11,7 @@ import hudson.model.TaskListener;
 import hudson.util.FormValidation;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import jenkins.plugins.office365connector.model.FactDefinition;
+import jenkins.plugins.office365connector.model.Mention;
 import jenkins.plugins.office365connector.utils.FormUtils;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.workflow.steps.Step;
@@ -32,6 +33,7 @@ public class Office365ConnectorSendStep extends Step {
     private List<FactDefinition> factDefinitions;
     private String color;
     private boolean adaptiveCards;
+    private List<Mention> mentions;
 
     @DataBoundConstructor
     public Office365ConnectorSendStep(String webhookUrl) {
@@ -91,6 +93,15 @@ public class Office365ConnectorSendStep extends Step {
     @DataBoundSetter
     public void setAdaptiveCards(boolean adaptiveCards) {
         this.adaptiveCards = adaptiveCards;
+    }
+
+    public List<Mention> getMentions() {
+        return mentions;
+    }
+
+    @DataBoundSetter
+    public void setMentions(List<Mention> mentions) {
+        this.mentions = mentions;
     }
 
     @Extension

--- a/src/main/java/jenkins/plugins/office365connector/workflow/StepParameters.java
+++ b/src/main/java/jenkins/plugins/office365connector/workflow/StepParameters.java
@@ -18,6 +18,7 @@ package jenkins.plugins.office365connector.workflow;
 import java.util.List;
 
 import jenkins.plugins.office365connector.model.FactDefinition;
+import jenkins.plugins.office365connector.model.Mention;
 
 /**
  * @author srhebbar
@@ -30,14 +31,16 @@ public class StepParameters {
     private final String color;
     private final boolean adaptiveCards;
     private final List<FactDefinition> factDefinitions;
+    private final List<Mention> mentions;
 
-    public StepParameters(String message, String webhookUrl, String status, List<FactDefinition> factDefinitions, String color, boolean adaptiveCards) {
+    public StepParameters(String message, String webhookUrl, String status, List<FactDefinition> factDefinitions, String color, boolean adaptiveCards, List<Mention> mentions) {
         this.message = message;
         this.webhookUrl = webhookUrl;
         this.status = status;
         this.factDefinitions = factDefinitions;
         this.color = color;
         this.adaptiveCards = adaptiveCards;
+        this.mentions = mentions;
     }
 
     public String getMessage() {
@@ -62,5 +65,9 @@ public class StepParameters {
 
     public boolean isAdaptiveCards() {
         return adaptiveCards;
+    }
+
+    public List<Mention> getMentions() {
+        return mentions;
     }
 }

--- a/src/main/resources/jenkins/plugins/office365connector/Webhook/config.jelly
+++ b/src/main/resources/jenkins/plugins/office365connector/Webhook/config.jelly
@@ -61,6 +61,11 @@
                 </f:repeatableProperty>
             </f:entry>
 
+            <f:entry title="Mentions" field="mentions">
+                <f:repeatableProperty minimum="0" field="mentions" add="Add Mention">
+                </f:repeatableProperty>
+            </f:entry>
+
             <f:entry title="Timeout" description="Timeout (in ms)" field="timeout">
                 <f:number default="${descriptor.defaultTimeout}"/>
             </f:entry>

--- a/src/main/resources/jenkins/plugins/office365connector/Webhook/help-mentions.html
+++ b/src/main/resources/jenkins/plugins/office365connector/Webhook/help-mentions.html
@@ -1,0 +1,6 @@
+<div align="help">
+  Mentions notify specific users in the Adaptive Card (Microsoft Teams only).
+  Set <b>User ID</b> to the user's Azure AD object id or UPN (e.g. user@example.com)
+  and <b>Name</b> to the display name shown in the card.
+  Mentions are only rendered when <b>Use AdaptiveCard Format</b> is enabled.
+</div>

--- a/src/main/resources/jenkins/plugins/office365connector/model/Mention/config.jelly
+++ b/src/main/resources/jenkins/plugins/office365connector/model/Mention/config.jelly
@@ -1,0 +1,14 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry title="User ID" field="userId">
+        <f:textbox/>
+    </f:entry>
+    <f:entry title="Name" field="name">
+        <f:textbox/>
+    </f:entry>
+    <f:entry>
+        <div align="right">
+            <f:repeatableDeleteButton/>
+        </div>
+    </f:entry>
+</j:jelly>

--- a/src/test/java/jenkins/plugins/office365connector/CardBuilderMessageCardTest.java
+++ b/src/test/java/jenkins/plugins/office365connector/CardBuilderMessageCardTest.java
@@ -425,7 +425,7 @@ class CardBuilderMessageCardTest extends AbstractTest {
         String status = Result.SUCCESS.toString();
         String color = "blue";
 
-        StepParameters stepParameters = new StepParameters(message, webhookUrl, status, Collections.emptyList(), color, false);
+        StepParameters stepParameters = new StepParameters(message, webhookUrl, status, Collections.emptyList(), color, false, Collections.emptyList());
 
         // then
         Card card = cardBuilder.createBuildMessageCard(stepParameters);
@@ -447,7 +447,7 @@ class CardBuilderMessageCardTest extends AbstractTest {
         String status = null;
         String color = "blue";
 
-        StepParameters stepParameters = new StepParameters(message, webhookUrl, status, Collections.emptyList(), color, false);
+        StepParameters stepParameters = new StepParameters(message, webhookUrl, status, Collections.emptyList(), color, false, Collections.emptyList());
 
         // then
         Card card = cardBuilder.createBuildMessageCard(stepParameters);
@@ -468,7 +468,7 @@ class CardBuilderMessageCardTest extends AbstractTest {
         String status = Result.ABORTED.toString();
         String color = null;
 
-        StepParameters stepParameters = new StepParameters(message, webhookUrl, status, Collections.emptyList(), color, false);
+        StepParameters stepParameters = new StepParameters(message, webhookUrl, status, Collections.emptyList(), color, false, Collections.emptyList());
 
         // then
         Card card = cardBuilder.createBuildMessageCard(stepParameters);

--- a/src/test/java/jenkins/plugins/office365connector/workflow/AdaptiveCardIT.java
+++ b/src/test/java/jenkins/plugins/office365connector/workflow/AdaptiveCardIT.java
@@ -103,7 +103,7 @@ class AdaptiveCardIT extends AbstractTest {
         // given
         StepParameters stepParameters = new StepParameters(
                 "helloMessage", ClassicDisplayURLProviderBuilder.LOCALHOST_URL_TEMPLATE,
-                "funnyStatus", Collections.emptyList(), "#FF00FF", false);
+                "funnyStatus", Collections.emptyList(), "#FF00FF", false, Collections.emptyList());
 
         when(run.getResult()).thenReturn(Result.FAILURE);
         Office365ConnectorWebhookNotifier notifier = new Office365ConnectorWebhookNotifier(run, mockListener());

--- a/src/test/java/jenkins/plugins/office365connector/workflow/SampleIT.java
+++ b/src/test/java/jenkins/plugins/office365connector/workflow/SampleIT.java
@@ -151,7 +151,7 @@ class SampleIT extends AbstractTest {
         // given
         StepParameters stepParameters = new StepParameters(
                 "helloMessage", ClassicDisplayURLProviderBuilder.LOCALHOST_URL_TEMPLATE,
-                "funnyStatus", Collections.emptyList(), "#FF00FF", false);
+                "funnyStatus", Collections.emptyList(), "#FF00FF", false, Collections.emptyList());
 
         when(run.getResult()).thenReturn(Result.FAILURE);
         Office365ConnectorWebhookNotifier notifier = new Office365ConnectorWebhookNotifier(run, mockListener());

--- a/src/test/java/jenkins/plugins/office365connector/workflow/StepParametersTest.java
+++ b/src/test/java/jenkins/plugins/office365connector/workflow/StepParametersTest.java
@@ -27,7 +27,7 @@ class StepParametersTest {
     @BeforeEach
     void setUp() {
         stepParameters = new StepParameters(
-                MESSAGE, WEBHOOK_URL, STATUS, Collections.singletonList(FACT_DEFINITION), COLOR, false);
+                MESSAGE, WEBHOOK_URL, STATUS, Collections.singletonList(FACT_DEFINITION), COLOR, false, Collections.emptyList());
     }
 
     @Test


### PR DESCRIPTION
The goal of thei PR is to add support for Mentions when posting a Teams message.
The change doesn't assume anything on the setup of the user (Local accounts, AD, Submitters, etc) to allow maximum flexibility in use cases.

### Testing done

Deployed the plugin on several instances and users are properly notified.
Only tested on pipeline jobs, using office365ConnectorSend function.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

